### PR TITLE
omitted flashes in IO

### DIFF
--- a/visual_behavior/io.py
+++ b/visual_behavior/io.py
@@ -171,10 +171,10 @@ def load_flashes(data, time=None):
             omitted_flash = pd.DataFrame(data['omitted_flash_frame_log'], columns=['frame'])
             omitted_flash['omitted'] = True
             stimdf = pd.merge(stimdf, omitted_flash, how='left', on='frame')
-            flashes = stimdf[(stimdf['state'].astype(int).diff() > 0) | (pd.isnull(stimdf['omitted'])==False)].reset_index()[['image_category', 'image_name', 'frame', 'omitted']]
+            flashes = stimdf[(stimdf['state'].astype(int).diff() > 0) | (pd.isnull(stimdf['omitted']) == False)].reset_index()[['image_category', 'image_name', 'frame', 'omitted']]
         else:
             flashes = stimdf[stimdf['state'].astype(int).diff() > 0].reset_index()[['image_category', 'image_name', 'frame']]
-        
+
         # flashes['change'] = (flashes['image_category'].diff()!=0)
         flashes['prior_image_category'] = flashes['image_category'].shift()
         flashes['image_category_change'] = flashes['image_category'].ne(flashes['prior_image_category']).astype(int)


### PR DESCRIPTION
added a few lines in io.load_flashes to include omitted flashes in the flash-wise dataframe.