### PR TITLE
removes omitted flashes from load_flashes. fixes #30.

### DIFF
--- a/visual_behavior/io.py
+++ b/visual_behavior/io.py
@@ -143,6 +143,7 @@ def load_omitted_flashes(data):
     omitted_flash['omitted'] = True
     return omitted_flash
 
+
 @data_or_pkl
 def load_flashes(data, time=None):
     """ Returns the stimulus flashes in an experiment.


### PR DESCRIPTION
note @saharmanavi this will break your code.

after trying to fix the bug that was introduced here, I'm not sure that load_flashes is the best place to label omitted flashes.

instead, this PR adds a "load_omitted_flashes" function, then the user can choose how (or not) to merge the omitted flash record with the flash record, rather than forcing a dependency between the two functions.

cc @dougollerenshaw 