### PR TITLE
moving things out of top level to prevent circular deps

### DIFF
--- a/visual_behavior/validation/__init__.py
+++ b/visual_behavior/validation/__init__.py
@@ -1,5 +1,0 @@
-
-def assert_is_valid_dataframe(df, schema_instance):
-    records = df.to_dict('records')
-    errors = schema_instance.validate(records, many=True)
-    assert (len(errors) == 0), errors

--- a/visual_behavior/validation/extended_trials.py
+++ b/visual_behavior/validation/extended_trials.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from .trials import validate_trials
 from ..schemas.extended_trials import ExtendedTrialSchema
-from ..validation import assert_is_valid_dataframe
+from .utils import assert_is_valid_dataframe
 
 
 def validate_schema(extended_trials):

--- a/visual_behavior/validation/trials.py
+++ b/visual_behavior/validation/trials.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from ..schemas.core import TrialSchema
-from ..validation import assert_is_valid_dataframe
+from .utils import assert_is_valid_dataframe
 
 
 def assert_is_int(x):

--- a/visual_behavior/validation/utils.py
+++ b/visual_behavior/validation/utils.py
@@ -1,0 +1,5 @@
+
+def assert_is_valid_dataframe(df, schema_instance):
+    records = df.to_dict('records')
+    errors = schema_instance.validate(records, many=True)
+    assert (len(errors) == 0), errors


### PR DESCRIPTION
this PR moves assert_is_valid_dataframe out of the init to prevent circular loading
