### PR TITLE
bug fix, edf date field datetime object instead of str

### DIFF
--- a/visual_behavior/translator/core/annotate.py
+++ b/visual_behavior/translator/core/annotate.py
@@ -86,7 +86,7 @@ def explode_startdatetime(df):
     --------
     io.load_trials
     """
-    df['date'] = df['startdatetime'].dt.date.astype(str)
+    df['date'] = df['startdatetime'].dt.date
     df['year'] = df['startdatetime'].dt.year
     df['month'] = df['startdatetime'].dt.month
     df['day'] = df['startdatetime'].dt.day


### PR DESCRIPTION
Schema wont dumps/validate test files or real files because date field will be populated with a string, not a datetime object.  This was not caught in unit tests because date was properly mocked-in in the fixture, but caught in integration.