### PR TITLE
removing cruff in makefile to build artifact for deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 
 PKG=visual_behavior
-REV=`git rev-parse HEAD | cut -c -7`
 UID=`id -u`
 
 clean:


### PR DESCRIPTION
Minor change to remove a typo in the makefile that runs the docker image based whl build