### PR TITLE
URGENT: fixes requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.9.0
 pandas>=0.22.0
 scipy>=1.0.0
 matplotlib>=2.1.1
-sklearn
+scikit-learn>=0.19.2
 tables==3.4.2
 deepdish>=0.3.6
 python-dateutil>=2.6.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
         "matplotlib",
         "pandas",
         "six",
-        "sklearn",  # should be pinned but versioning looks broken right now...
+        "scikit-learn>=0.19.2",
         "scipy>=1.0.0",
         "deepdish>=0.3.6",
         "numpy>=1.9.0",  # for science some packages need to be pinned


### PR DESCRIPTION
this PR fixes the requirements to use "scikit-learn" (the pip name of the package) instead of "sklearn" (which is something else)