### PR TITLE
workaround missing trial_params

### DIFF
--- a/tests/translator/foraging2/test_foraging2_translator.py
+++ b/tests/translator/foraging2/test_foraging2_translator.py
@@ -236,6 +236,25 @@ def test_data_to_trials(foraging2_data_fixture):
         check_less_precise=3,
     )
 
+    # regression test for https://github.com/AllenInstitute/visual_behavior_analysis/issues/289
+    data = foraging2_data_fixture.copy()
+    data['items']['behavior']['trial_log'][-1].pop('trial_params')
+    expected = EXPECTED_TRIALS.iloc[:-1]
+    # expected.set_index([0, 1])
+
+    trials = foraging2.data_to_trials(data)
+
+    pd.testing.assert_frame_equal(
+        trials,
+        expected,
+        check_column_type=False,
+        check_index_type=False,
+        check_dtype=False,
+        check_like=True,
+        check_exact=False,
+        check_less_precise=3,
+    )
+
 
 def test_data_to_visual_stimuli(
         foraging2_data_stage0_2018_05_10,

--- a/visual_behavior/translator/foraging2/__init__.py
+++ b/visual_behavior/translator/foraging2/__init__.py
@@ -285,6 +285,10 @@ def data_to_trials(data):
     for trial in trial_log:
         index = trial["index"]  # trial index
 
+        if 'trial_params' not in trial:
+            logger.error("No 'trial_params' in trial {}. Skipping. See https://github.com/AllenInstitute/visual_behavior_analysis/issues/289".format(index))
+            continue
+
         expand_dict(trials, annotate_licks(trial), index)
         expand_dict(trials, annotate_rewards(trial), index)
         expand_dict(trials, annotate_optogenetics(trial), index)


### PR DESCRIPTION
fixes #289 

note: adds errors to log on read when this error is hit.

```
["ERROR::visual_behavior.translator.foraging2::No 'trial_params' in trial 61. Skipping. See https://github.com/AllenInstitute/visual_behavior_analysis/issues/289",
 "ERROR::visual_behavior.translator.foraging2::No 'trial_params' in trial 319. Skipping. See https://github.com/AllenInstitute/visual_behavior_analysis/issues/289",
 "ERROR::visual_behavior.translator.foraging2::No 'trial_params' in trial 358. Skipping. See https://github.com/AllenInstitute/visual_behavior_analysis/issues/289",
 "ERROR::visual_behavior.translator.foraging2::No 'trial_params' in trial 367. Skipping. See https://github.com/AllenInstitute/visual_behavior_analysis/issues/289"]
```