### PR TITLE
dealing with warning: check type first resolves #413

### DIFF
--- a/visual_behavior/translator/core/annotate.py
+++ b/visual_behavior/translator/core/annotate.py
@@ -397,7 +397,7 @@ def update_times(trials, time):
 
     def update(fr):
         try:
-            if (fr is None) or (type(fr)==float and np.isnan(fr) == True):  # this should catch np.nans
+            if (fr is None) or (type(fr) == float and np.isnan(fr) == True):  # this should catch np.nans
                 return None
             else:  # this should be for floats
                 return time[int(fr)]


### PR DESCRIPTION
avoids repeated warning when running pytest in python3