### PR TITLE
add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,6 @@ figures/
 
 # vs code
 .idea/
+.vscode/
 
 \.DS_Store


### PR DESCRIPTION
One line of change. the .vscode folder exists on my mac only.