### PR TITLE
Fixing a mask length mismatch

### DIFF
--- a/visual_behavior/change_detection/trials/session_metrics.py
+++ b/visual_behavior/change_detection/trials/session_metrics.py
@@ -76,7 +76,7 @@ def reward_lick_latency(session_trials):
 def total_water(session_trials, trial_types=()):
     mask = masks.trial_types(session_trials, trial_types)
 
-    return session_trials[mask][(session_trials['reward_times'].map(len) > 0)]['reward_volume'].sum()
+    return session_trials[mask]['reward_volume'].sum()
 
 
 def earned_water(session_trials):


### PR DESCRIPTION
Jerome found a mask length mismatch in session_metrics.py when calculating the reward volume. This caused a warning in pandas 0.22, but seemed to lead to a hard failure in 0.23.