### PR TITLE
more plotting work: fix issues caused by tight layout

### DIFF
--- a/visual_behavior/visualization/extended_trials/mouse.py
+++ b/visual_behavior/visualization/extended_trials/mouse.py
@@ -203,7 +203,7 @@ def make_summary_figure(df_input, mouse_id=None, palette='trial_types', row_heig
     if row_height == 'variable':
         # plots with few rows look overcrowded. They need a larger row size to accomodate.
         # decrease row height linearly to a minimum of 0.5
-        row_height = max((-0.25 * len(df_input) + 1.25, 0.5))
+        row_height = max((-0.25 * len(df_input) + 2.25, 0.5))
 
     if len(df_input['startdatetime'].unique()) == len(df_input):
         df_summary = df_input
@@ -237,5 +237,9 @@ def make_summary_figure(df_input, mouse_id=None, palette='trial_types', row_heig
         axis.tick_params(bottom=False, left=False)
         for i in range(len(df_summary)):
             axis.axhspan(i - 0.5, i + 0.5, color=bar_colors[i % 2], zorder=-1, alpha=0.25)
+
+    fig.tight_layout()
+    if len(df_summary) > 1:
+        plt.subplots_adjust(wspace=0.075)
 
     return fig


### PR DESCRIPTION
tight_layout was causing problems, especially for plots with few rows. It interacted poorly with a suptitle, so I removed the suptitle. I also made the row heights decrease linearly to a minimum to avoid overcrowding when there were few rows.