### PR TITLE
Remove duplicate entries when making summary plot

### DIFF
--- a/visual_behavior/visualization/extended_trials/mouse.py
+++ b/visual_behavior/visualization/extended_trials/mouse.py
@@ -182,7 +182,7 @@ def make_trial_count_plot(df_summary, ax, palette='trial_types'):
 
 def add_y_labels(df_summary, ax):
 
-    dates = [d.strftime('%Y-%m-%d') for d in df_summary.startdatetime]
+    dates = [pd.to_datetime(d).strftime('%Y-%m-%d') for d in df_summary['startdatetime']]
     days_of_week = df_summary['startdatetime'].map(lambda x: pd.to_datetime(x).day_name())
     stages = [s for s in df_summary.stage]
     users = [user for user in df_summary.user_id]


### PR DESCRIPTION
@jeromelecoq ran into a problem caused by duplicate rows in the summary dataframe when generating the mouse summary plot. See issue #506.

This PR removes duplicates before plotting and issues a warning when doing so.