### PR TITLE
Fix loading hdf5 files with new versions of pandas

### DIFF
--- a/visual_behavior/ophys/dataset/visual_behavior_ophys_dataset.py
+++ b/visual_behavior/ophys/dataset/visual_behavior_ophys_dataset.py
@@ -96,14 +96,12 @@ class VisualBehaviorOphysDataset(object):
     analysis_dir = LazyLoadable('_analysis_dir', get_analysis_dir)
 
     def get_metadata(self):
-        # self._metadata = pd.read_hdf(os.path.join(self.analysis_dir, 'metadata.h5'), key='df', format='fixed')
         self._metadata = pd.read_hdf(os.path.join(self.analysis_dir, 'metadata.h5'), key='df')
         return self._metadata
 
     metadata = LazyLoadable('_metadata', get_metadata)
 
     def get_timestamps(self):
-        # self._timestamps = pd.read_hdf(os.path.join(self.analysis_dir, 'timestamps.h5'), key='df', format='fixed')
         self._timestamps = pd.read_hdf(os.path.join(self.analysis_dir, 'timestamps.h5'), key='df')
         return self._timestamps
 
@@ -122,10 +120,6 @@ class VisualBehaviorOphysDataset(object):
     timestamps_ophys = LazyLoadable('_timestamps_ophys', get_timestamps_ophys)
 
     def get_stimulus_table(self):
-        # self._stimulus_table = pd.read_hdf(
-        #     os.path.join(self.analysis_dir, 'stimulus_table.h5'),
-        #     key='df', format='fixed'
-        # )
         self._stimulus_table = pd.read_hdf(
             os.path.join(self.analysis_dir, 'stimulus_table.h5'),
             key='df'
@@ -150,10 +144,6 @@ class VisualBehaviorOphysDataset(object):
     stimulus_template = LazyLoadable('_stimulus_template', get_stimulus_template)
 
     def get_stimulus_metadata(self):
-        # self._stimulus_metadata = pd.read_hdf(
-        #     os.path.join(self.analysis_dir, 'stimulus_metadata.h5'),
-        #     key='df', format='fixed'
-        # )
         self._stimulus_metadata = pd.read_hdf(
             os.path.join(self.analysis_dir, 'stimulus_metadata.h5'),
             key='df'
@@ -164,31 +154,24 @@ class VisualBehaviorOphysDataset(object):
     stimulus_metadata = LazyLoadable('_stimulus_metadata', get_stimulus_metadata)
 
     def get_running_speed(self):
-        # self._running_speed = pd.read_hdf(os.path.join(self.analysis_dir, 'running_speed.h5'), key='df', format='fixed')
         self._running_speed = pd.read_hdf(os.path.join(self.analysis_dir, 'running_speed.h5'), key='df')
         return self._running_speed
 
     running_speed = LazyLoadable('_running_speed', get_running_speed)
 
     def get_licks(self):
-        # self._licks = pd.read_hdf(os.path.join(self.analysis_dir, 'licks.h5'), key='df', format='fixed')
         self._licks = pd.read_hdf(os.path.join(self.analysis_dir, 'licks.h5'), key='df')
         return self._licks
 
     licks = LazyLoadable('_licks', get_licks)
 
     def get_rewards(self):
-        # self._rewards = pd.read_hdf(os.path.join(self.analysis_dir, 'rewards.h5'), key='df', format='fixed')
         self._rewards = pd.read_hdf(os.path.join(self.analysis_dir, 'rewards.h5'), key='df')
         return self._rewards
 
     rewards = LazyLoadable('_rewards', get_rewards)
 
     def get_task_parameters(self):
-        # self._task_parameters = pd.read_hdf(
-        #     os.path.join(self.analysis_dir, 'task_parameters.h5'),
-        #     key='df', format='fixed'
-        # )
         self._task_parameters = pd.read_hdf(
             os.path.join(self.analysis_dir, 'task_parameters.h5'),
             key='df'
@@ -198,7 +181,6 @@ class VisualBehaviorOphysDataset(object):
     task_parameters = LazyLoadable('_task_parameters', get_task_parameters)
 
     def get_all_trials(self):
-        # self._all_trials = pd.read_hdf(os.path.join(self.analysis_dir, 'trials.h5'), key='df', format='fixed')
         self._all_trials = pd.read_hdf(os.path.join(self.analysis_dir, 'trials.h5'), key='df')
         return self._all_trials
 
@@ -273,8 +255,7 @@ class VisualBehaviorOphysDataset(object):
     events = LazyLoadable('_events', get_events)
 
     def get_roi_metrics(self):
-        # self._roi_metrics = pd.read_hdf(os.path.join(self.analysis_dir, 'roi_metrics.h5'), key='df', format='fixed')
-        self._roi_metrics = pd.read_hdf(os.path.join(self.analysis_dir, 'roi_metrics.h5'), key='df') #No support for format=fixed
+        self._roi_metrics = pd.read_hdf(os.path.join(self.analysis_dir, 'roi_metrics.h5'), key='df')
         return self._roi_metrics
 
     roi_metrics = LazyLoadable('_roi_metrics', get_roi_metrics)
@@ -317,10 +298,6 @@ class VisualBehaviorOphysDataset(object):
     average_image = LazyLoadable('_average_image', get_average_image)
 
     def get_motion_correction(self):
-        # self._motion_correction = pd.read_hdf(
-        #     os.path.join(self.analysis_dir, 'motion_correction.h5'),
-        #     key='df', format='fixed'
-        # )
         self._motion_correction = pd.read_hdf(
             os.path.join(self.analysis_dir, 'motion_correction.h5'),
             key='df'

--- a/visual_behavior/ophys/response_analysis/response_analysis.py
+++ b/visual_behavior/ophys/response_analysis/response_analysis.py
@@ -132,7 +132,6 @@ class ResponseAnalysis(object):
         else:
             if os.path.exists(self.get_trial_response_df_path()):
                 print('loading trial response dataframe')
-                # self.trial_response_df = pd.read_hdf(self.get_trial_response_df_path(), key='df', format='fixed')
                 self.trial_response_df = pd.read_hdf(self.get_trial_response_df_path(), key='df')
                 tdf = self.trial_response_df
                 tdf.cell = [int(cell) for cell in tdf.cell.values]
@@ -248,7 +247,6 @@ class ResponseAnalysis(object):
         else:
             if os.path.exists(self.get_flash_response_df_path()):
                 print('loading flash response dataframe')
-                # self.flash_response_df = pd.read_hdf(self.get_flash_response_df_path(), key='df', format='fixed')
                 self.flash_response_df = pd.read_hdf(self.get_flash_response_df_path(), key='df')
                 fdf = self.flash_response_df
                 fdf.cell = [int(cell) for cell in fdf.cell.values]
@@ -336,7 +334,6 @@ class ResponseAnalysis(object):
         else:
             if os.path.exists(self.get_omitted_flash_response_df_path()):
                 print('loading omitted flash response dataframe')
-                # self.omitted_flash_response_df = pd.read_hdf(self.get_omitted_flash_response_df_path(), key='df', format='fixed')
                 self.omitted_flash_response_df = pd.read_hdf(self.get_omitted_flash_response_df_path(), key='df')
                 fdf = self.omitted_flash_response_df
                 fdf.cell = [int(cell) for cell in fdf.cell.values]


### PR DESCRIPTION
This PR addresses issue #513 by changing all of the calls to `pandas.read_hdf()` to no longer pass 'format' as a kwarg. We used to do this, and the passed kwarg was ignored by HDFStore.open because it wasn't a defined keyword arg for that method, but no alarms were raised.

See: https://github.com/pandas-dev/pandas/issues/13291

 In newer versions of pandas there is an exception raised if you try to pass 'format' to the `read_hdf()` method. Removing this kwarg: 
1. Won't change the output of `read_hdf`, as the kwarg was being ignored before, and
2. Allows me to run Marina's old notebooks with VBA analysis code and `pandas==0.24.2`

TODO: 
- [ ] Is feature/production_analysis the right target branch for this PR? 