### PR TITLE
Adds a Win 10 device name to devices.py

### DIFF
--- a/visual_behavior/devices.py
+++ b/visual_behavior/devices.py
@@ -34,6 +34,7 @@ RIG_NAME = {
     'W7VS-SYSLOGIC35': 'E5',
     'W7VS-SYSLOGIC36': 'E6',
     'W7DT102905': 'F1',
+    'W10DT102905': 'F1',
     'W7DT102904': 'F2',
     'W7DT102903': 'F3',
     'W7DT102914': 'F4',


### PR DESCRIPTION
This PR allows MPE to test upgrading a single computer on rig F1 to windows 10. It adds a new mapping between the Win10 computer name and the rig ID 'F1'