### PR TITLE
Remove misplaced omitted flash frames

### DIFF
--- a/visual_behavior/translator/foraging2/extract_stimuli.py
+++ b/visual_behavior/translator/foraging2/extract_stimuli.py
@@ -107,8 +107,30 @@ def check_for_omitted_flashes(stimulus_df, time, omitted_flash_frame_log=None, p
 
         elif omitted_flash_frame_log is not None:
             for stimuli_group_name, omitted_flash_frames in iteritems(omitted_flash_frame_log):
-                omitted_flash_times = [time[frame] for frame in omitted_flash_frames]
-                for omitted_flash_frame, omitted_flash_time in zip(omitted_flash_frames, omitted_flash_times):
+                ### Remove omitted flashes that also exist in the stimulus log
+                stim_frames = stimulus_df['frame'].values
+                omitted_flash_frames = np.array(omitted_flash_frames)
+                offsets_to_test = np.arange(-3, 4)
+                # Init bool array to hold results of in1d tests
+                omitted_in_stims = np.zeros((len(offsets_to_test),
+                                             len(omitted_flash_frames)),
+                                            dtype=bool)
+                # Test to see if omitted frames are in stim frames for each offset
+                for indOffset, offset in enumerate(offsets_to_test):
+                    omitted_in_stims[indOffset,:] = np.in1d(omitted_flash_frames+offset,
+                                                            stim_frames)
+                # Filter out any frames that matched for any offset
+                matched_any_offset = np.any(omitted_in_stims, axis=0)
+                if np.any(matched_any_offset):
+                    logger.warn("Removing {} omitted stimuli that also exist in frame log".format(
+                        np.sum(matched_any_offset)))
+                was_true_omitted = np.logical_not(matched_any_offset) #bool
+                omitted_flash_frames_to_keep = omitted_flash_frames[was_true_omitted]
+
+                omitted_flash_times = [time[frame] for frame in omitted_flash_frames_to_keep]
+
+                for omitted_flash_frame, omitted_flash_time in zip(omitted_flash_frames_to_keep,
+                                                                   omitted_flash_times):
 
                     omitted_flash_list.append({
                         'frame': omitted_flash_frame,


### PR DESCRIPTION
Core data now does  not include frames from omitted_frame_log that also
appear in the stimulus log, +/- 3 frames.

Addresses #511 


