### PR TITLE
Fix/issue511

### DIFF
--- a/visual_behavior/translator/foraging2/extract_stimuli.py
+++ b/visual_behavior/translator/foraging2/extract_stimuli.py
@@ -113,8 +113,8 @@ def check_for_omitted_flashes(stimulus_df, time, omitted_flash_frame_log=None, p
 
                 #  Test offsets of omitted flash frames to see if they are in the stim log
                 offsets = np.arange(-3, 4)
-                offsetArr = np.add(np.repeat(omittedFrames[:, np.newaxis], offsets.shape[0], axis=1), offsets)
-                matched_any_offset = np.any(np.isin(offsetArr, stimFrames), axis=1)
+                offset_arr = np.add(np.repeat(omitted_flash_frames[:, np.newaxis], offsets.shape[0], axis=1), offsets)
+                matched_any_offset = np.any(np.isin(offset_arr, stim_frames), axis=1)
 
                 #  Remove omitted flashes that also exist in the stimulus log
                 if np.any(matched_any_offset):


### PR DESCRIPTION
This PR implements a faster solution (with no loops) for checking whether frames in the omitted log also exist in the stimulus log, and also addresses an additional problem - the fact that some omitted frames were included twice in the omitted log. This happened when both calls to the `camstim` function that decides whether to omit a stimulus decide to omit it (both will log the frame). So we need to `unique` the omitted frames to include in the core data object. 