### PR TITLE
Remove unsupported kwarg from call to utilities.get_response_rates

### DIFF
--- a/visual_behavior/visualization/ophys/experiment_summary_figures.py
+++ b/visual_behavior/visualization/ophys/experiment_summary_figures.py
@@ -329,7 +329,7 @@ def plot_d_prime(trials, d_prime, ax=None):
 
 def plot_hit_false_alarm_rates(trials, ax=None):
     trials['auto_rewarded'] = False
-    hr, cr, d_prime = vbut.get_response_rates(trials, sliding_window=100, reward_window=None)
+    hr, cr, d_prime = vbut.get_response_rates(trials, sliding_window=100)
 
     if ax is None:
         fig, ax = plt.subplots(figsize=(10, 2))


### PR DESCRIPTION
Addresses #526 by removing an unsupported kwarg from a call to `utilities.get_response_rates()`. Only 1 tox test fails after implementing this fix. The test that still fails is `tests/validation/test_regression.py::test_sessions`