### PR TITLE
Fix failing QC metrics after inclusion of movies in visual stimuli

### DIFF
--- a/visual_behavior/validation/qc.py
+++ b/visual_behavior/validation/qc.py
@@ -43,13 +43,13 @@ def define_validation_functions(core_data):
 
     PERIODIC_FLASH = core_data['metadata']['periodic_flash']
 
-    # When checking validate_flash_blank_durations, we need to send only the periodic flash stimuli 
-    # presented during trials, and not the movie stimuli that can be included at the end of 
+    # When checking validate_flash_blank_durations, we need to send only the periodic flash stimuli
+    # presented during trials, and not the movie stimuli that can be included at the end of
     # sessions. We also want to exclude any countdown stimuli from before the first trial starts.
 
     # Boolean array for selecting stimuli that were presented as part of a trial
-    trial_stimuli =((core_data['visual_stimuli']['frame'] >= core_data['trials'].iloc[0]['startframe']) & \
-		    (core_data['visual_stimuli']['end_frame'] <= core_data['trials'].iloc[-1]['endframe'])).values
+    trial_stimuli = ((core_data['visual_stimuli']['frame'] >= core_data['trials'].iloc[0]['startframe']) &
+                     (core_data['visual_stimuli']['end_frame'] <= core_data['trials'].iloc[-1]['endframe'])).values
 
     validation_functions = {
         # et.validate_schema


### PR DESCRIPTION
The QC metrics need the following updates to run after we started including
the movies as part of the visual stimuli:

* Pass the visual stimuli when building the extended trials dataframe,
  allowing an existing fix for removing the movie stimuli from the last
  trial to work.
* When passing visual stimuli to validate_flash_blank_durations, first
  remove any stimuli that don't occur between the first frame of the
  first trial and the last frame of the last trial. This removes any
  countdown / fingerprint movie stimuli, which cause this qc metric to
  fail.