### PR TITLE
Refactor validation function to use core data instead of extended

### DIFF
--- a/visual_behavior/validation/extended_trials.py
+++ b/visual_behavior/validation/extended_trials.py
@@ -3,6 +3,8 @@ import pandas as pd
 import six
 from scipy import stats
 
+from visual_behavior.translator.core import annotate
+
 from ..schemas.extended_trials import ExtendedTrialSchema
 from .utils import assert_is_valid_dataframe, nanis_equal, all_close
 
@@ -425,14 +427,16 @@ def validate_never_more_than_one_reward(trials):
     return np.max(trials['number_of_rewards']) <= 1
 
 
-def validate_lick_after_scheduled_on_go_catch_trials(trials, abort_on_early_response, distribution_type, tolerance=0.01):
+def validate_lick_after_scheduled_on_go_catch_trials(core_data, abort_on_early_response, distribution_type, tolerance=0.01):
     '''
     if licks occur before a scheduled change time/flash, the trial ends
     Therefore, no non-aborted trials should have a lick before the scheduled change time,
     except when abort_on_early_response is False
     '''
 
-    nonaborted_trials = trials[trials.trial_type != 'aborted']
+    trials = core_data['trials']
+    trial_type = annotate.categorize_trials(trials)
+    nonaborted_trials = trials[trial_type != 'aborted']
     # We can only check this if there is at least 1 nonaborted trial.
     if distribution_type.lower() == 'geometric':
         return True

--- a/visual_behavior/validation/qc.py
+++ b/visual_behavior/validation/qc.py
@@ -65,7 +65,7 @@ def define_validation_functions(core_data):
         et.validate_reward_when_lick_in_window: (trials,),
         et.validate_licks_near_every_reward: (trials, ),
         et.validate_never_more_than_one_reward: (trials,),
-        et.validate_lick_after_scheduled_on_go_catch_trials: (trials, ABORT_ON_EARLY_RESPONSE, DISTRIBUTION),
+        et.validate_lick_after_scheduled_on_go_catch_trials: (core_data, ABORT_ON_EARLY_RESPONSE, DISTRIBUTION),
         et.validate_initial_matches_final: (trials,),
         et.validate_first_lick_after_change_on_nonaborted: (trials, ABORT_ON_EARLY_RESPONSE),
         et.validate_trial_ends_without_licks: (trials, MIN_NO_LICK_TIME,),


### PR DESCRIPTION
Addresses issue #539 

The validation function `validate_lick_after_scheduled_on_go_catch_trials`
should use the lick and change times from the core data object, and not from
the extended trials dataframe, because these times get rebased to the nearest
frame in the extended trials dataframe, and this can cause this function to
report that a session fails QC even though it should pass, and the lick times
were correct relative to the change time in the original core_data.