### PR TITLE
add NP0, NP1, NP2, NP4 to devices

### DIFF
--- a/visual_behavior/devices.py
+++ b/visual_behavior/devices.py
@@ -83,7 +83,11 @@ RIG_NAME = {
     'W7DT2P3STiM': '2P3',
     'W7DT2P4STIM': '2P4',
     'W7DT2P5STIM': '2P5',
+    'W10DTSM112721': 'NP0',
+    'W10DTSM118294': 'NP1',
+    'W10DTSM118295': 'NP2',
     'W10DTSM118296': 'NP3',
+    'W10DTSM118293': 'NP4',
     'meso1stim': 'MS1',
     'localhost': 'localhost'
 }


### PR DESCRIPTION
adds missing rig ids, fixes rig_id = 'unknown' in behavior session log