### PR TITLE
add trial adjusted d prime peak to default summary metrics

### DIFF
--- a/visual_behavior/change_detection/trials/summarize.py
+++ b/visual_behavior/change_detection/trials/summarize.py
@@ -6,6 +6,7 @@ from ... import metrics
 from ...translator.core.annotate import annotate_epochs, annotate_change_detect
 from functools import partial
 
+
 def create_summarizer(**kwargs):
     """ creates a function that can be applied to a dataframe
 

--- a/visual_behavior/change_detection/trials/summarize.py
+++ b/visual_behavior/change_detection/trials/summarize.py
@@ -4,7 +4,7 @@ import numpy as np
 from . import session_metrics
 from ... import metrics
 from ...translator.core.annotate import annotate_epochs, annotate_change_detect
-
+from functools import partial
 
 def create_summarizer(**kwargs):
     """ creates a function that can be applied to a dataframe
@@ -53,6 +53,7 @@ DEFAULT_SUMMARY_METRICS = dict(
     # behavior_session_uuid=session_metrics.session_id,
     session_duration=session_metrics.session_duration,
     d_prime_peak=session_metrics.peak_dprime,
+    d_prime_peak_trial_adjusted=partial(session_metrics.peak_dprime, first_valid_trial=100, apply_trial_number_limit=True),
     d_prime=lambda grp: session_metrics.discrim(grp, 'change', 'detect', metric=metrics.d_prime),
     discrim_p=lambda grp: session_metrics.discrim(grp, 'change', 'detect', metric=metrics.discrim_p),
     response_bias=lambda grp: session_metrics.response_bias(grp, 'detect'),

--- a/visual_behavior/visualization/extended_trials/mouse.py
+++ b/visual_behavior/visualization/extended_trials/mouse.py
@@ -124,13 +124,23 @@ def make_performance_plot(df_summary, ax, palette='trial_types'):
 
 def make_dprime_plot(df_summary, ax, reward_window=None, sliding_window=100, height=0.8):
 
-    ax.barh(
-        np.arange(len(df_summary)),
-        df_summary['d_prime_peak'].values,
-        height=height,
-        color='DimGray',
-        alpha=1
-    )
+    b1 = ax.barh(
+            np.arange(len(df_summary)),
+            df_summary['d_prime_peak'].values,
+            height=height,
+            color='k',
+            alpha=1
+        )
+
+    if 'd_prime_peak_trial_adjusted' in df_summary.columns:
+        b2 = ax.barh(
+                np.arange(len(df_summary)),
+                df_summary['d_prime_peak_trial_adjusted'].values,
+                height=height,
+                color='0.5',
+                alpha=1
+            )
+        ax.legend([b1, b2], ['raw', 'adjusted'])
 
     ax.set_title('PEAK \ndprime')
     ax.set_xlabel('Max dprime')


### PR DESCRIPTION
I've added a new metric to the DEFAULT_SUMMARY_METRICS dictionary. Now when you call session_level_summary, you should get both d_prime_peak (the raw metric) and d_prime_peak_trial_adjusted (the adjusted metric). 

This should make it easy to display both metrics in mouse-seeks since now "get_full_summary_stats" in the ophys extractor change_detection dataset will return a dictionary with both of them.