### PR TITLE
Silence warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="visual-behavior",
-    version="0.8.1.dev0",
+    version="version="0.8.1.dev0"",
     author="Allen Institute for Brain Science",
     author_email="marinag@alleninstitute.org, dougo@alleninstitute.org",
     description="analysis package for visual behavior",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="visual-behavior",
-    version="version="0.8.1.dev0"",
+    version="0.8.2.dev0",
     author="Allen Institute for Brain Science",
     author_email="marinag@alleninstitute.org, dougo@alleninstitute.org",
     description="analysis package for visual behavior",

--- a/visual_behavior/__init__.py
+++ b/visual_behavior/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "__version__ = "0.8.1.dev0""
+__version__ = "0.8.2.dev0"

--- a/visual_behavior/__init__.py
+++ b/visual_behavior/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.1.dev0"
+__version__ = "__version__ = "0.8.1.dev0""

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -273,6 +273,7 @@ class BehaviorOphysDataset(BehaviorOphysSession):
         cell_specimen_table = super().cell_specimen_table
         if self.include_invalid_rois == False:
             cell_specimen_table = cell_specimen_table.query('valid_roi')
+        cell_specimen_table = cell_specimen_table.copy()
         # add cell index corresponding to the index of the cell in dff_traces_array
         cell_specimen_ids = np.sort(cell_specimen_table.index.values)
         if 'cell_index' not in cell_specimen_table.columns:

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -80,8 +80,7 @@ def get_behavior_model_outputs_dir():
 
 def get_cache_dir():
     """Get directory of data cache for analysis - this should be the standard cache location"""
-    #cache_dir = "//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/2020_cache/production_cache"
-    cache_dir = "//allen/programs/braintv/workgroups/nc-ophys/alex.piet/GLM/manifest/"
+    cache_dir = "//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/2020_cache/production_cache"
     return cache_dir
 
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -159,7 +159,7 @@ def get_filtered_ophys_experiment_table(include_failed_data=False):
         experiments = experiments.set_index('ophys_experiment_id')
         experiments.to_csv(os.path.join(get_cache_dir(), 'filtered_ophys_experiment_table.csv'))
         experiments = experiments.reset_index()
-        experiments = experiments.drop(columns='index',errors='ignore')
+        experiments = experiments.drop(columns='index', errors='ignore')
     if include_failed_data:
         experiments = filtering.limit_to_experiments_with_final_qc_state(experiments)
     else:
@@ -278,7 +278,7 @@ class BehaviorOphysDataset(BehaviorOphysSession):
         cell_specimen_ids = np.sort(cell_specimen_table.index.values)
         if 'cell_index' not in cell_specimen_table.columns:
             cell_specimen_table['cell_index'] = [np.where(cell_specimen_ids == cell_specimen_id)[0][0] for
-                                                        cell_specimen_id in cell_specimen_table.index.values]
+                                                 cell_specimen_id in cell_specimen_table.index.values]
             cell_specimen_table = processing.shift_image_masks(cell_specimen_table)
         self._cell_specimen_table = cell_specimen_table
         return self._cell_specimen_table

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -80,7 +80,8 @@ def get_behavior_model_outputs_dir():
 
 def get_cache_dir():
     """Get directory of data cache for analysis - this should be the standard cache location"""
-    cache_dir = "//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/2020_cache/production_cache"
+    #cache_dir = "//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/2020_cache/production_cache"
+    cache_dir = "//allen/programs/braintv/workgroups/nc-ophys/alex.piet/GLM/manifest/"
     return cache_dir
 
 
@@ -159,7 +160,7 @@ def get_filtered_ophys_experiment_table(include_failed_data=False):
         experiments = experiments.set_index('ophys_experiment_id')
         experiments.to_csv(os.path.join(get_cache_dir(), 'filtered_ophys_experiment_table.csv'))
         experiments = experiments.reset_index()
-        experiments = experiments.drop(columns='index')
+        experiments = experiments.drop(columns='index',errors='ignore')
     if include_failed_data:
         experiments = filtering.limit_to_experiments_with_final_qc_state(experiments)
     else:
@@ -272,11 +273,11 @@ class BehaviorOphysDataset(BehaviorOphysSession):
     def cell_specimen_table(self):
         cell_specimen_table = super().cell_specimen_table
         if self.include_invalid_rois == False:
-            cell_specimen_table = cell_specimen_table[cell_specimen_table.valid_roi == True]
+            cell_specimen_table = cell_specimen_table.query('valid_roi')
         # add cell index corresponding to the index of the cell in dff_traces_array
         cell_specimen_ids = np.sort(cell_specimen_table.index.values)
         if 'cell_index' not in cell_specimen_table.columns:
-            cell_specimen_table.loc[:, 'cell_index'] = [np.where(cell_specimen_ids == cell_specimen_id)[0][0] for
+            cell_specimen_table['cell_index'] = [np.where(cell_specimen_ids == cell_specimen_id)[0][0] for
                                                         cell_specimen_id in cell_specimen_table.index.values]
             cell_specimen_table = processing.shift_image_masks(cell_specimen_table)
         self._cell_specimen_table = cell_specimen_table

--- a/visual_behavior/ophys/response_analysis/response_analysis.py
+++ b/visual_behavior/ophys/response_analysis/response_analysis.py
@@ -79,13 +79,13 @@ class ResponseAnalysis(object):
                  use_extended_stimulus_presentations=False, overwrite_analysis_files=False, dataframe_format='wide'):
         self.dataset = dataset
         # promote ophys timestamps up to the top level
-        self.ophys_timestamps = self.dataset.ophys_timestamps # THROWS WARNING
+        self.ophys_timestamps = self.dataset.ophys_timestamps  # THROWS WARNING
         # promote stimulus_presentations to the top level
         self.stimulus_presentations = self.dataset.stimulus_presentations
         # promote dff_traces to the top level
         self.dff_traces = self.dataset.dff_traces
         # promote cell_specimen_table to the top level
-        self.cell_specimen_table = self.dataset.cell_specimen_table 
+        self.cell_specimen_table = self.dataset.cell_specimen_table
         self.use_events = use_events
         if analysis_cache_dir is None:
             self.analysis_cache_dir = loading.get_analysis_cache_dir()

--- a/visual_behavior/ophys/response_analysis/response_analysis.py
+++ b/visual_behavior/ophys/response_analysis/response_analysis.py
@@ -79,13 +79,13 @@ class ResponseAnalysis(object):
                  use_extended_stimulus_presentations=False, overwrite_analysis_files=False, dataframe_format='wide'):
         self.dataset = dataset
         # promote ophys timestamps up to the top level
-        self.ophys_timestamps = self.dataset.ophys_timestamps
+        self.ophys_timestamps = self.dataset.ophys_timestamps # THROWS WARNING
         # promote stimulus_presentations to the top level
         self.stimulus_presentations = self.dataset.stimulus_presentations
         # promote dff_traces to the top level
         self.dff_traces = self.dataset.dff_traces
         # promote cell_specimen_table to the top level
-        self.cell_specimen_table = self.dataset.cell_specimen_table
+        self.cell_specimen_table = self.dataset.cell_specimen_table 
         self.use_events = use_events
         if analysis_cache_dir is None:
             self.analysis_cache_dir = loading.get_analysis_cache_dir()
@@ -106,6 +106,7 @@ class ResponseAnalysis(object):
         self.ophys_frame_rate = self.dataset.metadata['ophys_frame_rate']
         self.stimulus_frame_rate = self.dataset.metadata['stimulus_frame_rate']
         if 'blank_duration_sec' in self.dataset.task_parameters.keys():
+
             self.blank_duration = self.dataset.task_parameters['blank_duration_sec'][0]
             # self.dataset.running_speed = self.dataset.running_speed_df
         else:


### PR DESCRIPTION
Deals with this setting on copy warning regardless of whether invalid_ROIS are included (previous iteration was dependent on that). 

@dougollerenshaw you commented on the earlier draft whether there is an problem with ignoring the errors. That error I'm ignoring is just when the code is dropping a column, and it ignores the error if the column isnt there. I think its ok, because its one of those things where pandas sometimes makes the index a column when you reset the index, and sometimes it drops it. 