### PR TITLE
generalize the `get_pkl_path` method for behavior only sessions

### DIFF
--- a/visual_behavior/database.py
+++ b/visual_behavior/database.py
@@ -176,8 +176,6 @@ def get_pkl_path(session_id=None, id_type='BehaviorSession'):
     '''
     get the path to a pkl file for a given session
     '''
-    # if id_type == 'behavior_session_uuid':
-    #     session_id = convert_id({foraging_id: session_id}, 'behavior_session_id')
 
     rec = get_well_known_files(session_id, attachable_id_type=id_type).loc['StimulusPickle']
 


### PR DESCRIPTION
generalizes the `get_pkl_path` method for behavior only sessions. Previously this method only worked for ophys sessions