### PR TITLE
fix eye/behavior line labels to match SDK convention

### DIFF
--- a/tests/ophys/dataset/test_visual_behavior_ophys_dataset.py
+++ b/tests/ophys/dataset/test_visual_behavior_ophys_dataset.py
@@ -198,7 +198,7 @@ def ophys_data_dir(tmpdir_factory,
     
     # stim template
     stimulus_template_path = os.path.join(analysis_folder_path, 'stimulus_template.h5')
-    with h5py.File(stimulus_template_path) as stimulus_template_file:
+    with h5py.File(stimulus_template_path, 'w') as stimulus_template_file:
         stimulus_template_file.create_dataset('data', data=stimulus_template)
         
     # stim metadata
@@ -223,7 +223,7 @@ def ophys_data_dir(tmpdir_factory,
     
     # max projection
     max_projection_path = os.path.join(analysis_folder_path, 'max_projection.h5')
-    with h5py.File(max_projection_path) as max_projection_file:
+    with h5py.File(max_projection_path, 'w') as max_projection_file:
         max_projection_file.create_dataset('data', data=max_projection)
         
     # motion correction

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -315,16 +315,16 @@ def get_sync_data(lims_data, analysis_dir, use_acq_trigger):
         stim_photodiode = sync_dataset.get_rising_edges('stim_photodiode') / sample_freq
     elif 'photodiode' in meta_data['line_labels']:
         stim_photodiode = sync_dataset.get_rising_edges('photodiode') / sample_freq
-    if 'cam1_exposure' in meta_data['line_labels']:
-        eye_tracking = sync_dataset.get_rising_edges('cam1_exposure') / sample_freq
-    elif 'cam1' in meta_data['line_labels']:
-        eye_tracking = sync_dataset.get_rising_edges('cam1') / sample_freq
+    if 'cam2_exposure' in meta_data['line_labels']:
+        eye_tracking = sync_dataset.get_rising_edges('cam2_exposure') / sample_freq
+    elif 'cam2' in meta_data['line_labels']:
+        eye_tracking = sync_dataset.get_rising_edges('cam2') / sample_freq
     elif 'eye_tracking' in meta_data['line_labels']:
         eye_tracking = sync_dataset.get_rising_edges('eye_tracking') / sample_freq
-    if 'cam2_exposure' in meta_data['line_labels']:
-        behavior_monitoring = sync_dataset.get_rising_edges('cam2_exposure') / sample_freq
-    elif 'cam2' in meta_data['line_labels']:
-        behavior_monitoring = sync_dataset.get_rising_edges('cam2') / sample_freq
+    if 'cam1_exposure' in meta_data['line_labels']:
+        behavior_monitoring = sync_dataset.get_rising_edges('cam1_exposure') / sample_freq
+    elif 'cam1' in meta_data['line_labels']:
+        behavior_monitoring = sync_dataset.get_rising_edges('cam1') / sample_freq
     elif 'behavior_monitoring' in meta_data['line_labels']:
         behavior_monitoring = sync_dataset.get_rising_edges('behavior_monitoring') / sample_freq
     # some experiments have 2P frames prior to stimulus start - restrict to timestamps after trigger for 2P6 only


### PR DESCRIPTION
Working with @DowntonCrabby to fix line label mismatch issue. Line labels in data_access/utilities for eye and behavior cameras were reversed from the convention outlined here:

https://github.com/AllenInstitute/AllenSDK/blob/be4dfb1dada2e8466ce1091e02d40a5ef17e7b15/allensdk/internal/brain_observatory/time_sync.py#L22

We updated VBA to match the SDK convention