### PR TITLE
add notebook detailing stimulus warp

### DIFF
--- a/notebooks/stimulus_warping_example.ipynb
+++ b/notebooks/stimulus_warping_example.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from allensdk.brain_observatory import stimulus_info\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build a 'display mask' using the sdk `make_display_mask` function\n",
+    "This gives us an array of ones/zeros denoting which pixels will be visible on the monitor *after* warping  \n",
+    "The default input size is a 1920x1200 pixel image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display_mask = stimulus_info.make_display_mask()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show the display mask\n",
+    "White pixels will be visible on the screen after warp  \n",
+    "Black pixels will not be visible"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7f036008d910>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAD0CAYAAAB3sfb1AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAhbUlEQVR4nO3de3BU553m8e9Pt0YSRkLCCBAgySBjwI4ByzaEQCgbsI1j8C2OPa4aO3GV11Px7CSpTeKZ2dqdP3arJpPd8TrlVCYQPIu3bA/exCaM79gBw8Y3LsZGCCSEQEECBLqABLrR6nf/0JEjbAG6oD7nqJ9PlYrut4+6Hx2Jp0+/5/Rpc84hIiKJIcnvACIiEj8qfRGRBKLSFxFJICp9EZEEotIXEUkgKn0RkQQS99I3s9vNrNzMKs3sqXg/vohIIrN4HqdvZslABbAMqAG2Aw8558riFkJEJIHFe0v/JqDSOVflnOsE/g1YFecMIiIJK96lnw8c6XW9xhsTEZE4SPE7wJeZ2ePA497VG/zMIiISUvXOuSv7uiHepV8LTOl1fbI39gXn3GpgNYCZ6cRAIiIDV32hG+I9vbMdKDazIjNLAx4ENsY5g4hIworrlr5zLmpmTwJvA8nAc865vfHMICKSyOJ6yOZAaXpHRGRQdjrnSvq6Qe/IFRFJICp9EZEEotIXEUkgKn0RkQSi0hcRSSAqfRGRBKLSFxFJICp9EZEEotIXEUkgKn0RkQSi0hcRSSAqfRGRBKLSFxFJICp9EZEEotIXEUkgKn0RkQSi0hcRSSAqfRGRBBLXz8gVCQMzIzk5+SvjkUiEUaNGfWW8s7OTtra2r4zHYjFisdiwZBQZLJW+jGhJSUlEIhFSUlLIzs4mEokwbtw4srKyGD9+POPGjSM5OZnp06cTiUQAyM7OZsKECV+5rzFjxpCdnf2V8dbWVurr678y3tTURF1dHQBdXV1UVlbS0dFBS0sLR44cob29ndraWqLRKI2NjXR1ddHW1qYnChlWKn0JNTMjEomQnZ1NdnY2+fn5FBUVcdVVVzFu3DiKiooYP348V1xxBVlZWaSlpZGWlkZKSgpmhpldlhzTp08f0PI9rwLa29vp6uqiqamJtrY2jh07Rk1NDSdPnqSyspLq6mpqa2upr6/n1KlTtLe360lBhsScc35nuCAzC244iavk5GTS09OZMGECRUVFzJgxg+nTpzNt2jQKCwsZP348GRkZpKen9zk1E1axWIyOjg5aW1s5efIkf/rTn6iqqqKqqop9+/ZRVVVFbW0tZ8+eJRqN+h1XgmOnc66krxtU+hI4qamp5OTkUFRURHFxMfPmzeP6669n0qRJTJw4kczMzBFV7IMVi8VobW3lxIkTHD16lNLSUnbt2kV5eTkHDx6kvr6ejo4Ov2OKP1T6EkxJSUlkZ2czdepUrrvuOhYsWMD111/PVVddRU5ODmlpaX5HDJ1oNMqpU6eorq6mtLSUjz76iE8//ZRDhw7R2NioVwSJQaUvwZCcnExubi6zZ89m4cKFLFiwgFmzZjFhwgQikchlm2OX83V2dtLQ0MC+ffvYvn0727Zt47PPPqOuro5z5875HU8uP5W++CMpKYmcnByuvfZaFi5cyKJFi7juuusYP348KSk6jsAvsViMxsZG9u3bxx//+Ee2bt36xZNAV1eX3/Fk6C5/6ZvZFOB5IA9wwGrn3DNmlgOsBwqBw8ADzrkm696EewZYAbQCjzrndl3iMVT6IZSRkcH06dNZuHAhS5cu5YYbbiA/P18lH2BdXV3U19eze/duNm/ezJYtW9i/fz+nT5/2O5oMzrCU/kRgonNul5ldAewE7gYeBRqdc/9oZk8BY51zPzWzFcBf0136NwPPOOduvsRjqPRDwMwYN24cc+fOZfny5dxyyy3MmDGDjIwMv6PJIHV0dFBdXc2WLVt466232LFjB7W1tTpcNDyGf3rHzH4PPOt9LXHOHfOeGLY452aY2a+9yy95y5f3LHeR+1TpB1RSUhKTJk1iyZIlLF++nCVLljBp0iQdVTMCxWIx6uvr+eCDD3jnnXfYtGkT1dXV2hcQbMNb+mZWCGwFrgX+5JzL9sYNaHLOZZvZa8A/Ouf+n3fbe8BPnXM7LnK/Kv0AMTMmTpzILbfcwj333MM3vvENrrzySu18TTCnTp1ix44dbNiwgbfffpuqqiq9AgieC5b+kCdZzWw08DvgB8655t4F4JxzAy1uM3sceHyoueTyyc3NZeHChdx9990sW7aM/Px8FX0Cy87OZunSpSxdupTGxka2bNnCq6++yubNmzl69ChBPjhEhrilb2apwGvA2865f/bGvpi20fROeI0aNYqSkhLuv/9+7rzzToqKijR1IxfknOPYsWO8/fbb/O53v2Pr1q20tLT4HSuRDcuOXAPW0b3T9ge9xn8ONPTakZvjnPuJmd0JPMmfd+T+wjl30yUeQ6UfR0lJSRQWFrJq1SruvfdeSkpK+jyrpMjFRKNRysrK2LBhA6+88gqlpaU6DDT+hqX0vwFsA/YAPRN6fwd8DLwMTAWq6T5ks9F7kngWuJ3uQza/e7H5fO8xVPpxkJGRwaJFi3jwwQdZsWIF48eP9zuSjBDNzc1s3ryZF198kXfffZfGxka/IyUKvTlLvmrSpEncf//9PPzww8ydO5fU1FS/I8kIFYvFqKioYP369bz44oscOHBAc//DS6Uv3ZKTk5k5cyaPPvoo999/PwUFBX5HkgRTX1/Pa6+9xpo1a9ixYwednZ1+RxqJVPqJLhKJsGjRIp544gmWLVvGmDFj/I4kCa69vZ0//vGPrFmzhtdff50zZ874HWkkUeknqszMTO68807+6q/+ivnz52vHrARONBplz549rF27lpdeeknz/peHSj/RZGZmsmLFCn74wx9y44036rw3EnixWIz9+/fz7LPPsn79epX/0Kj0E0VmZibf/va3eeKJJ7jhhhtU9hI6sViM8vJy1q1bx5o1a1T+g6PSH+kyMjK48847+fGPf8zcuXNV9hJ6zjkqKip49tlneeGFF2hqavI7Upio9EeylJQUnnvuOR566CGVvYw4sViM999/n5UrV2pnb/9dsPST4p1ELr9p06axatUqFb6MSElJSSxatIj58+f7HWVEUOmPACtWrNAhmDKipaSksGrVKr9jjAgq/ZBLS0vj3nvv9TuGyLC7/fbbycnJ8TtG6Kn0Q664uJg5c+b4HUNk2BUVFVFS0uc0tQyASj/k7rjjDkaPHu13DJFhl5yczF133eV3jNBT6YdYWloaK1eu9DuGSNwsX76crKwsv2OEmko/xKZOncrXvvY1v2OIxE1RURHz5s3zO0aoqfRD7LbbbtNWjySU1NRUvvWtb/kdI9RU+iGVlJTEbbfd5ncMkbhbsmQJ6enpfscILZV+SOXl5elIBklIV199NVdddZXfMUJLpR9SN954I3l5eX7HEIm70aNHs3TpUr9jhJZKP6Ruu+02kpL065PEtHTpUpKTk/2OEUpqjRAaNWoUCxYs8DuGiG/mzJmjd+cOkko/hAoKCpg2bZrfMUR8M3HiRB26OUgq/RD6+te/rhOsSUJLTk5m8eLFfscIJZV+CH3zm9/0O4KI7xYuXKjTiQ+CSj9kMjMzufHGG/2OIeK7mTNnMn78eL9jhI5KP2QKCwuZOnWq3zFEfJebm8t1113nd4zQUemHzNy5c3VWTRG65/W//vWv+x0jdIZc+maWbGafmtlr3vUiM/vYzCrNbL2ZpXnjEe96pXd74VAfOxHdfPPNfkcQCYySkhIdrz9Al2NL/2+Afb2u/wx42jk3HWgCHvPGHwOavPGnveVkACKRiI7PF+ll9uzZOpJtgIZU+mY2GbgT+I133YBbgN96i6wD7vYur/Ku491+q7e89NO4ceMoKCjwO4ZIYEyYMEHvWRmgoW7p/y/gJ0DMu54LnHLORb3rNUC+dzkfOALg3X7aW/48Zva4me0wsx1DzDbiTJs2jezsbL9jiARGJBLRztwBGnTpm9m3gBPOuZ2XMQ/OudXOuRLnnE4h+SXXX3+9jksW+RK9M3dghtIgC4GVZrYCGAWMAZ4Bss0sxduanwzUesvXAlOAGjNLAbKAhiE8fsLRH7fIV/VsDEWj0UsvLIPf0nfO/a1zbrJzrhB4EPiDc+5hYDNwv7fYI8Dvvcsbvet4t//BOecG+/iJRi9jRfqmac+BGY7j9H8K/MjMKumes1/rja8Fcr3xHwFPDcNjj1jaiSvSt5ycHPLz8y+9oABDm975gnNuC7DFu1wF3NTHMu3Aty/H4yWiyZMn69A0kT5EIhFmzpzJZ5995neUUNA7ckOiuLiYtLQ0v2OIBI6ZMXv2bL9jhIZKPyRmzpzpdwSRwJo1axZ620//qPRDwMyYNWuW3zFEAquoqIjU1FS/Y4SCSj8ERo0apXcdilzEhAkTyMrK8jtGKKj0Q2DMmDHk5eX5HUMksMaOHcvEiRP9jhEKKv0QyMvL05E7IheRlpamz5noJ5V+CBQUFOjIHZGLSEpKorCw0O8YoaDSD4FJkyaRlKRflcjF6M2L/aMmCQFtwYhc2vTp03XYZj+o9ENg+vTpfkcQCbzc3Fx9ilY/qPQDLjk5mdzcr3zsgIh8SV5eHpFIxO8YgafSD7jU1FQdrinSD+PGjdPZNvtBpR9wo0eP1uGaIv2QlpZGZmam3zECT6UfcKNGjWL06NF+xxAJvPT0dMaPH+93jMBT6QfchAkTyMjI8DuGSOCZmU7F0A8q/YCLRCI6IkGkH5KSkvRhKv2g0g+4qVOnqvRF+knvXL80lX7AaWpHpP+Ki4v9jhB4Kv2AGzVqlN8RREJDpyu5NK2hgNO7cUX6T0e6XZpKP+B0LhGR/ps6daq29i9Ba0dEJIGo9APMzJg8ebLfMURkBFHpB5iZ6RQMIgMwZswYfUD6Jaj0RWTEyM3N1bH6l6DSFxFJIEMqfTPLNrPfmtl+M9tnZgvMLMfMNpnZAe/fsd6yZma/MLNKM/vczOZdnh9BRET6a6hb+s8AbznnrgGuB/YBTwHvOeeKgfe86wB3AMXe1+PAr4b42CIiMkCDLn0zywIWA2sBnHOdzrlTwCpgnbfYOuBu7/Iq4HnX7SMg28wmDvbxRURk4IaypV8EnAT+1cw+NbPfmFkmkOecO+Ytcxzo+dinfOBIr++v8cbOY2aPm9kOM9sxhGwiItKHoZR+CjAP+JVzbi5wlj9P5QDgnHOAG8idOudWO+dKnHMlQ8gmIiJ9GErp1wA1zrmPveu/pftJoK5n2sb794R3ey0wpdf3T/bGREQkTgZd+s6548ARM5vhDd0KlAEbgUe8sUeA33uXNwJ/6R3FMx843WsaSERE4iBliN//18ALZpYGVAHfpfuJ5GUzewyoBh7wln0DWAFUAq3esiIiEkdDKn3n3G6gr7n3W/tY1gHfH8rjiYhcTEtLC9Fo1O8YgaZ35AaYc4729na/Y4iERn19PR0dHX7HCDSVfoA55zh06JDfMURkBFHpB1z3rJiIyOWh0heREaOurk4bSpeg0g+46upqvyOIhEZDQ4NK/xJU+gHX3NzsdwQRGUFU+gF37tw5vyOIhEZVVZXfEQJPpR9wVVVVdHV1+R1DJBTOnj3rd4TAU+kHXDQa1RylSD845zh58qTfMQJPpR9wx44d09aLSD/EYjGVfj+o9AOuvb1d7zAU6YeOjg6ampr8jhF4Kv2Aa25upr6+3u8YIoHX2dmpo936QaUfcNFolMbGRr9jiAReQ0MDp0+f9jtG4Kn0Ay4ajWqeUqQf6uvrdYLCflDpB5xzjoMHD/odQyTw6urq9L6WflDph0BNTY3fEUQC79ChQzq8uR9U+iFQU1OjP2aRS9DGUf+o9EPg0KFDetkqchGaBu0/lX4IHD9+nJaWFr9jiATWuXPndEbaflLph8Dp06d1BI/IRZw+fZqjR4/6HSMUVPoh0NbWprMHilzE8ePHOXXqlN8xQkGlHwKxWIz9+/f7HUMksKqrq+ns7PQ7Riio9EOirKzM7wgigbV//35isZjfMUJBpR8S5eXlRKNRv2OIBNLevXv9jhAaKv2QOHLkiI7gEelDZ2cnpaWlfscIDZV+SJw4cUJvPhHpw6lTp6itrfU7RmgMqfTN7IdmttfMSs3sJTMbZWZFZvaxmVWa2XozS/OWjXjXK73bCy/LT5Ag2tvbNa8v0ofDhw/T0NDgd4zQGHTpm1k+8B+BEufctUAy8CDwM+Bp59x0oAl4zPuWx4Amb/xpbznpJ+ccu3bt8juGSODs2bNHR+4MwFCnd1KAdDNLATKAY8AtwG+929cBd3uXV3nX8W6/1cxsiI+fUHbv3q0PSRf5kp07d/odIVQGXfrOuVrgfwB/orvsTwM7gVPOuZ7DTGqAfO9yPnDE+96ot3zul+/XzB43sx1mtmOw2UaqiooK7cwV6eXcuXN8/vnnfscIlaFM74yle+u9CJgEZAK3DzWQc261c67EOVcy1Psaaerq6jhy5IjfMUQC4+TJk1RUVPgdI1SGMr2zFDjknDvpnDsHvAIsBLK96R6AyUDPbvVaYAqAd3sWoL0vA9DW1qaXsiK9VFRU6PQLAzSU0v8TMN/MMry5+VuBMmAzcL+3zCPA773LG73reLf/wekk8QP2wQcf+B1BJDC2b9+u044P0FDm9D+me4fsLmCPd1+rgZ8CPzKzSrrn7Nd637IWyPXGfwQ8NYTcCevTTz/V54CK0H1Oqg8//NDvGKFjQd7YNrPghvNJVlYWO3fuZNq0aX5HEfFVU1MT8+bN4/Dhw35HCaKdF9ovqnfkhkxzc7OO1xcBDhw4wLFjx/yOEToq/ZBxzrFt2za/Y4j47sMPP6Sjo8PvGKGj0g+hbdu20dra6ncMEd/EYjHef/99v2OEkko/hA4cOKDPA5WE1tDQwCeffOJ3jFBS6YdQa2sr27dv9zuGiG/Kysqoq6vzO0YoqfRDyDnHW2+9RZCPvBIZTps2bdKHCg2SSj+kPvzwQ5qamvyOIRJ37e3tbNq0ye8YoaXSD6mamhp2797tdwyRuDt06JA+W2IIVPohFY1Geeedd/yOIRJ327Zt48yZM37HCC2Vfoi9/fbbOnRTEkpXVxdvvPGG3zFCTaUfYhUVFZSXl/sdQyRujh49qpMODpFKP8RaW1t5/fXX/Y4hEjebN2+mvr7e7xihptIPuX//93/XWTclIcRiMTZs2KBDlYdIpR9ypaWl7Nu3z+8YIsPu6NGjfPzxx37HCD2Vfsi1trby2muv+R1DZNht3rxZZ9W8DFT6I8Arr7xCW1ub3zFEhk0sFuPVV1/V1M5loNIfAfbt28f777+v/xAyYn3++eds3brV7xgjgkp/BOjo6ODhhx/mxz/+sc6+KSNKQ0MDP//5z1m5ciUNDQ1+xxkR9HGJI0x+fj7f+973eOyxx5gyZQpJSXpel/A5ceIEL7/8Mr/85S8pLy/Xq9iBu+DHJar0R6jx48dz33338eSTT3LNNdeo/CUUampq+M1vfsO6deuorq5W2Q+eSj9R5eTk8NBDD/HEE09wzTXXkJKS4nckkfM456iurmbdunWsXbuWI0eO+B1pJFDpJ7oxY8Zwxx138P3vf5+bbrqJSCTidyRJcNFolL1797JmzRpefvllTp486XekkUSlL90ikQgLFizgscce46677iIrK8vvSJJgWltb2bp1K7/+9a959913dcbM4aHSl/MlJydTXFzMo48+yne+8x2mTp2qeX8ZNs456uvr2bBhA2vXruXTTz+ls7PT71gjmUpfLiwvL49bbrmFRx55hMWLF5Oenu53JBkhzp07x86dO3n++ed58803tXM2flT6cmlpaWl87Wtf44EHHuC+++6joKCA5ORkv2NJyDjnqKur4/XXX+eFF17gk08+4ezZs37HSjSDL30zew74FnDCOXetN5YDrAcKgcPAA865JjMz4BlgBdAKPOqc2+V9zyPAf/bu9r8559ZdKrVK3z/jxo3jm9/8Jn/xF3/BkiVLyMnJ8TuSBNyZM2f46KOPWL9+PW+99Ra1tbXaqvfPkEp/MXAGeL5X6f8T0Oic+0czewoY65z7qZmtAP6a7tK/GXjGOXez9ySxAygBHLATuME5d9FP9lbp+y85OZmioiKWLVvGPffcw0033aSdv/KFtrY2PvvsMzZu3Mgbb7zBvn37NFcfDEOb3jGzQuC1XqVfDixxzh0zs4nAFufcDDP7tXf5pd7L9Xw55/6DN37echd5XJV+gKSkpHD11VezcuVKVq5cyezZsxkzZozfsSTOWltbqays5I033mDDhg3s3r2bjo4Ov2PJ+S5Y+oN9p06ec67nHKfHgTzvcj7Q+50VNd7Yhca/wsweBx4fZC4ZRtFolLKyMsrKynj66acpKChg2bJl3H333ZSUlJCVlUX3DJ+MNGfOnKG0tJSNGzfy5ptvcuDAAc3Th9SQ357pnHOXc4vcObcaWA3a0g+yjo4OKioqqKioYPXq1RQUFLBw4UKWLl3KwoULmTx5MqmpqX7HlEGKxWIcP36cHTt2sGnTJrZs2UJlZaU+pW0EGGzp15nZxF7TOye88VpgSq/lJntjtXRP8fQe3zLIx5aAOXfuHJWVlVRWVvL888+TnZ3NDTfcwK233srixYuZNWuWXgUEnHOOs2fPcvDgQbZu3crmzZv54IMPqK+vp6ury+94chkNdk7/50BDrx25Oc65n5jZncCT/HlH7i+cczd5O3J3AvO8u9xF947cxks8rrb0Qy4SiZCfn8+8efNYvnw5JSUlFBcXk5mZqScBn7W3t1NdXc327dt57733+OSTTzh8+DCtra1+R5OhG9LROy/RvZU+DqgD/iuwAXgZmApU033IZqN3yOazwO10H7L5XefcDu9+vgf8nXe3/90596+XSq3SH3kyMjKYOnUq1113HYsXL2bevHlcffXVjB07Vu8JGEaxWIyWlhYqKyu/+ECS3bt3U1VVRUtLiw6tHHn05iwJptTUVCZMmMDMmTOZP38+s2fPZs6cOUycOJGMjAw9EQyCc462tjZOnDjBnj17KCsr48MPP2Tv3r3U1NRoXj4xqPQlHMyMzMxMJkyYQHFxMXPmzOHaa69lxowZTJkyhezsbNLS0vyOGRjnzp2jpaWFo0ePUl5eTllZGZ9//jmlpaUcP36c5uZmYrGY3zEl/lT6Em6RSISxY8cyefJkiouLueaaayguLmb69Onk5eUxduzYEfvKoKuri7a2NlpaWjhx4gQHDx6koqKC8vJyKioqOHLkCA0NDbS1tWmaRnqo9GVkikQiZGZmkpOTw6RJkygsLCQ/P5/JkydTVFT0xRPC6NGjSU9PJz09naSkpEDsRHbO4Zyjvb2djo4OTp8+zZkzZzh+/DgHDx7kxIkTVFdXU1VVRV1dHfX19TQ3N9PR0aFyl0tR6UviSUpKIi0tjbS0NK644goyMzPJz88nEolQUFDA6NGjueKKKygoKMDMyM3N5corr/zi+9PT08+73l+nTp2iubn5i+stLS3U1tYCcPz4cU6ePElnZyeVlZVEo1GOHDlCW1sbTU1NRKNR2tvbNSUjQ6XSF7mUpKSk8z5TIDU1lYyMjAHfT8+Wew/nnI51l3i77KdhEBlxYrHYeVvY0WiUtrY2HxOJXH76qCQRkQSi0hcRSSAqfRGRBKLSFxFJICp9EZEEotIXEUkgKn0RkQSi0hcRSSAqfRGRBKLSFxFJICp9EZEEotIXEUkgKn0RkQSi0hcRSSAqfRGRBKLSFxFJICp9EZEEotIXEUkgKn0RkQSi0hcRSSAqfRGRBKLSFxFJICp9EZEEkuJ3gEs4A5T7HWIAxgH1focYgDDlDVNWCFfeMGUF5e2PggvdEPTSL3fOlfgdor/MbIfyDo8wZYVw5Q1TVlDeodL0johIAlHpi4gkkKCX/mq/AwyQ8g6fMGWFcOUNU1ZQ3iEx55zfGUREJE6CvqUvIiKXUWBL38xuN7NyM6s0s6cCkGeKmW02szIz22tmf+ON/4OZ1ZrZbu9rRa/v+Vsvf7mZ3eZD5sNmtsfLtcMbyzGzTWZ2wPt3rDduZvYLL+/nZjYvzlln9FqHu82s2cx+EJT1a2bPmdkJMyvtNTbgdWlmj3jLHzCzR+Kc9+dmtt/L9KqZZXvjhWbW1msd/0uv77nB+xuq9H4mi1PWAf/e49UZF8i7vlfWw2a22xv3dd32yTkXuC8gGTgIXAWkAZ8Bs3zONBGY512+AqgAZgH/APynPpaf5eWOAEXez5Mc58yHgXFfGvsn4Cnv8lPAz7zLK4A3AQPmAx/7/Ps/TvexxoFYv8BiYB5QOth1CeQAVd6/Y73LY+OYdzmQ4l3+Wa+8hb2X+9L9fOL9DOb9THfEKeuAfu/x7Iy+8n7p9v8J/JcgrNu+voK6pX8TUOmcq3LOdQL/BqzyM5Bz7phzbpd3uQXYB+Rf5FtWAf/mnOtwzh0CKun+ufy2CljnXV4H3N1r/HnX7SMg28wm+pAP4FbgoHOu+iLLxHX9Oue2Ao19ZBjIurwN2OSca3TONQGbgNvjldc5945zLupd/QiYfLH78DKPcc595Lpb6nn+/DMOa9aLuNDvPW6dcbG83tb6A8BLF7uPeK3bvgS19POBI72u13Dxgo0rMysE5gIfe0NPei+Zn+t5iU8wfgYHvGNmO83scW8szzl3zLt8HMjzLgchb48HOf8/TVDX70DXZRAy9/ge3VuXPYrM7FMze9/MFnlj+XRn7BHvvAP5vQdl3S4C6pxzB3qNBWrdBrX0A8vMRgO/A37gnGsGfgVMA+YAx+h+aRcU33DOzQPuAL5vZot73+htYQTq8C0zSwNWAv/XGwry+v1CENflhZjZ3wNR4AVv6Bgw1Tk3F/gR8KKZjfErnycUv/c+PMT5GyyBW7dBLf1aYEqv65O9MV+ZWSrdhf+Cc+4VAOdcnXOuyzkXA9bw5ykG338G51yt9+8J4FUvW13PtI337wlvcd/zeu4Adjnn6iDY65eBr0vfM5vZo8C3gIe9Jyq8qZIG7/JOuufGr/ay9Z4CilveQfzeg7BuU4B7gfU9Y0Fct0Et/e1AsZkVeVt+DwIb/QzkzdWtBfY55/6513jvee97gJ49+huBB80sYmZFQDHdO27ilTfTzK7ouUz3TrxSL1fPUSOPAL/vlfcvvSNP5gOne01dxNN5W0pBXb+9MgxkXb4NLDezsd50xXJvLC7M7HbgJ8BK51xrr/ErzSzZu3wV3euyysvcbGbzvb//v+z1Mw531oH+3oPQGUuB/c65L6Ztgrhuh31P8WC/6D4CooLuZ8a/D0Ceb9D98v1zYLf3tQL4P8Aeb3wjMLHX9/y9l7+cOO2Z7/XYV9F9BMNnwN6edQjkAu8BB4B3gRxv3IBfenn3ACU+rONMoAHI6jUWiPVL9xPRMeAc3fOvjw1mXdI9l17pfX03znkr6Z737vn7/Rdv2fu8v5HdwC7grl73U0J34R4EnsV7Q2ccsg749x6vzugrrzf+v4EnvrSsr+u2ry+9I1dEJIEEdXpHRESGgUpfRCSBqPRFRBKISl9EJIGo9EVEEohKX0Qkgaj0RUQSiEpfRCSB/H8ZAzPfN75VPAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig,ax=plt.subplots()\n",
+    "ax.imshow(display_mask.T, cmap='gray')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "visual_behavior",
+   "language": "python",
+   "name": "visual_behavior"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
adds a notebook showing how to use the SDK `make_display_mask` function, which denotes which pixels will be visible on the screen after stimulus warping