### PR TITLE
pin SDK at 2.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://aibs.jfrog.io/aibs/api/pypi/ni-pypi-local/simple
-allensdk; python_version >= '3.0'
+allensdk<=2.3.2; python_version >= '3.0'
 six>=1.11.0
 numpy>=1.15.4
 pandas==0.25.3


### PR DESCRIPTION
To avoid problems stemming from issue #696
We should unpin the SDK after #696 is resolved