### PR TITLE
add code to build dff stats table

### DIFF
--- a/scripts/deploy_log_dff_stats.py
+++ b/scripts/deploy_log_dff_stats.py
@@ -1,0 +1,41 @@
+import os
+import argparse
+import sys
+import time
+import pandas as pd
+import visual_behavior.data_access.loading as loading
+sys.path.append('/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/src/')
+from pbstools import pbstools  # NOQA E402
+
+parser = argparse.ArgumentParser(description='run sdk validation')
+parser.add_argument('--env', type=str, default='vba', metavar='name of conda environment to use')
+
+job_dir = r"/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/cluster_jobs/job_records"
+
+job_settings = {'queue': 'braintv',
+                'mem': '2g',
+                'walltime': '0:05:00',
+                'ppn': 1,
+                }
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    python_executable = "{}/.conda/envs/{}/bin/python".format(os.path.expanduser('~'), args.env)
+    print('python executable = {}'.format(python_executable))
+    python_file = "{}/code/visual_behavior_analysis/scripts/log_dff_stats.py".format(os.path.expanduser('~'))
+    print('python file = {}'.format(python_file))
+    ophys_experiment_table = loading.get_filtered_ophys_experiment_table()
+
+    for ii, ophys_experiment_id in enumerate(ophys_experiment_table.index):
+
+        print('starting cluster job for {}'.format(ophys_experiment_id))
+        job_title = '{}_log_dff_stats'.format(ophys_experiment_id)
+        pbstools.PythonJob(
+            python_file,
+            python_executable,
+            python_args="--oeid {}".format(ophys_experiment_id),
+            jobname=job_title,
+            jobdir=job_dir,
+            **job_settings
+        ).run(dryrun=False)
+        time.sleep(0.001)

--- a/scripts/log_dff_stats.py
+++ b/scripts/log_dff_stats.py
@@ -1,0 +1,55 @@
+import visual_behavior.data_access.loading as loading
+import visual_behavior.data_access.processing as processing
+import visual_behavior.database as db
+import argparse
+import pandas as pd
+import time
+
+parser = argparse.ArgumentParser(description='log dff stats')
+parser.add_argument('--oeid', type=int, default=0, metavar='ophys experiment ID')
+parser.add_argument(
+        '--verbose',
+        help='boolean, not followed by an argument. Enables verbose mode. False by default.',
+        action='store_true'
+    )
+
+def main(oeid, verbose=True):
+    t0 = time.time()
+    # load the session
+    session = loading.get_ophys_dataset(oeid)
+    if verbose:
+        print('done loading session at {:0.2f} seconds'.format(time.time() - t0))
+
+    # add dff stats to the cell_specimen_table
+    df = processing.add_dff_stats_to_specimen_table(session)
+    if verbose:
+        print('done adding dff_stats at {:0.2f} seconds'.format(time.time() - t0))
+    
+    # add a column containing the ophys_experiment_id
+    df['ophys_experiment_id'] = oeid
+    if verbose:
+        print('done appending oeid {:0.2f} seconds'.format(time.time() - t0))
+        print('full list of dataframe columns:')
+        for column in df.columns:
+            print('\t{}'.format(column))
+
+    # convert the df to a list of dicts:
+    records = df.drop(columns=['image_mask','roi_mask']).reset_index().to_dict(orient='records')
+    if verbose:
+        print('done converting df to list of dicts at {:0.2f} seconds'.format(time.time() - t0))
+
+    # for each row, log the record to mongo
+    for record in records:
+        if verbose:
+            print('logging record for roi_id {} to mongo at {:0.2f} seconds'.format(record['cell_roi_id'], time.time() - t0))
+        db.log_cell_dff_data(record)
+    if verbose:
+        print('done logging records to mongo at {:0.2f} seconds'.format(time.time() - t0))
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    if args.oeid != 0:
+        main(args.oeid, args.verbose)
+    else:
+        print('must enter an ophys_experiment_id. Use the --oeid flag, followed by the ID')

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -2160,11 +2160,11 @@ def get_cell_summary(search_dict={}):
         pandas dataframe with one row per cell
         see database.get_cell_dff_data for description of columns
     '''
-    cell_table = db.get_cell_dff_data(search_dict = search_dict)
+    cell_table = db.get_cell_dff_data(search_dict=search_dict)
     experiment_table = get_filtered_ophys_experiment_table().reset_index()
     cell_table = cell_table.merge(
         experiment_table,
-        left_on = 'ophys_experiment_id',
-        right_on = 'ophys_experiment_id'
+        left_on='ophys_experiment_id',
+        right_on='ophys_experiment_id'
     )
     return cell_table

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -2147,3 +2147,24 @@ def get_container_response_df(container_id, df_name='omission_response_df', use_
         odf['session_number'] = experiments_table.loc[ophys_experiment_id].session_number
         container_df = pd.concat([container_df, odf])
     return container_df
+
+
+def get_cell_summary(search_dict={}):
+    '''
+    gets summary stats for all cells
+    relies on cache of summary stats in internal mongo database
+    merges in filtered_ophys_experiment_table for convenience
+    input:
+        search_dict -- dictionary of key/value pairs to constrain search (empty dict returns all cells)
+    returns:
+        pandas dataframe with one row per cell
+        see database.get_cell_dff_data for description of columns
+    '''
+    cell_table = db.get_cell_dff_data(search_dict = search_dict)
+    experiment_table = get_filtered_ophys_experiment_table().reset_index()
+    cell_table = cell_table.merge(
+        experiment_table,
+        left_on = 'ophys_experiment_id',
+        right_on = 'ophys_experiment_id'
+    )
+    return cell_table

--- a/visual_behavior/database.py
+++ b/visual_behavior/database.py
@@ -765,17 +765,47 @@ def log_cell_dff_data(record):
     db_conn.close()
 
 
-def get_cell_dff_data(search_dict={}):
+def get_cell_dff_data(search_dict={}, return_id=False):
     '''
     retrieve information from the 'dff_summary' collection in 'ophys_data' mongo database
     pass in a `search_dict` to constrain the search
     passing an empty dict (default) returns the full collection
     Note that the query itself is fast (tens of ms), but returning a large table can be slow (~30 seconds for the full collection)
+    inputs:
+        search_dict: a dictionary of key/value pairs to constrain the search (columns must be one of those available as an output - see below)
+        return_id: If True, returns a column containing the internal mongo index has of each entry (default = False)
     returns: pandas dataframe
+        columns:
+            The following come directly from the `cell_specimen_table` in the AllenSDK
+                cell_specimen_id: ID of each cell to facilitate cell matching. ID will be shared across ROIs from unique sessions that are identified as matches
+                cell_roi_id: Unique ID for each cell
+                height: height, in pixels, of ROI mask
+                width: width, in pixels, of ROI mask
+                x: x-position of mask, in pixels
+                y: y-position of mask, in pixels
+                mask_image_plane: image plane of corresponding mask. Integer ranging from 0 to 7
+                max_correction_{up, down, left, right}: the maximum translation, in pixels, of this ROI during motion correction
+                valid_roi: boolean denoting whether the ROI was deemed valid after ROI filtering
+            The following are appended and come from the pandas.describe() method on the deltaF/F (`dff`) trace for the cell
+                ophys_experiment_id: the associated ophys_experiment_id
+                previous_cell_specimen_ids: a list of cell_specimen_ids associated with this ROI in previous cell_matchting runs (not exhaustive)
+                count: length of dff vector
+                mean: mean of dff vector
+                std: standard devitation of dff vector
+                min: min of dff vector
+                max: max of dff vector
+                25%, 50%, 75%: lower, middle (median) and upper quartile values
     '''
     db_conn = Database('visual_behavior_data')
     collection = db_conn['ophys_data']['dff_summary']
     res = pd.DataFrame(list(collection.find(search_dict)))
     db_conn.close()
+
+    if not return_id:
+        res = res.drop(columns=['_id'])
+
+    # drop `index` column if it exists
+    if 'index' in res.columns:
+        res = res.drop(columns=['index'])
 
     return res


### PR DESCRIPTION
* adds a function to `data_access.processing` called `add_dff_stats_to_specimen_table` that takes the session object as the input and returns a cell_specimen_table with statistics on dff_traces appended (stats are provided by `pd.describe()` and include mean, std, 25%, 50%,75%, min, max)
* adds a script called `log_dff_stats.py` that will take an ophys_experiment_id as an input, call `add_dff_stats_to_specimen_table`, then log the resulting table to a mongo collection called `['ophys_data']['dff_summary']`
* adds a script called `deploy_log_dff_stats.py` that will iterate over the `filtered_ophys_experiment_table` and create one cluster job per experiment to execute `log_dff_stats.py`
* adds a function to `database.py` called `log_cell_dff_data` that handles writing of a single dff_stats record to mongo
* adds a function to `database.py` called `get_cell_dff_data` that facilitates searching mongo for the dff_stats