### PR TITLE
fix data loading issues

### DIFF
--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -277,7 +277,7 @@ class BehaviorOphysDataset(BehaviorOphysSession):
     @property
     def analysis_folder(self):
         analysis_cache_dir = get_analysis_cache_dir()
-        candidates = glob.glob(os.path.join(analysis_cache_dir, '{}_*'.format(int(ophys_experiment_id))))
+        candidates = glob.glob(os.path.join(analysis_cache_dir, '{}_*'.format(int(self.ophys_experiment_id))))
         if len(candidates) == 1:
             self._analysis_folder = candidates[0]
         elif len(candidates) == 0:
@@ -638,7 +638,7 @@ def get_ophys_dataset(ophys_experiment_id, include_invalid_rois=False, sdk_only=
     else:
         api = BehaviorOphysLimsApi(ophys_experiment_id)
         dataset = BehaviorOphysDataset(api, include_invalid_rois)
-        print('loading data for {}'.format(dataset.analysis_folder)) if verbose else None # required to ensure analysis folder is created before other methods are called
+        print('loading data for {}'.format(dataset.analysis_folder)) if verbose else None  # required to ensure analysis folder is created before other methods are called
     return dataset
 
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -288,7 +288,7 @@ class BehaviorOphysDataset(BehaviorOphysSession):
             date = m['experiment_datetime']
             date = str(date)[:10]
             date = date[2:4] + date[5:7] + date[8:10]
-            self._analysis_folder = str(m['ophys_experiment_id']) + '_' + str(m['donor_id']) + '_' + date + '_' + m[
+            self._analysis_folder = str(int(m['ophys_experiment_id'])) + '_' + str(int(m['donor_id'])) + '_' + date + '_' + m[
                 'targeted_structure'] + '_' + str(m['imaging_depth']) + '_' + m['driver_line'][0] + '_' + m[
                                         'rig_name'] + '_' + m['session_type']
             os.mkdir(os.path.join(analysis_cache_dir, self._analysis_folder))


### PR DESCRIPTION
* fixes issue in data_access.loading.BehaviorOphysDataset that was leading to ambiguity in analysis folder (if ophys_experiment_id was passed as a float, a new folder would be created, leading to ambiguity)
* adds 'sdk_only' option to data_access.loading.get_ophys_data() to allow all extra processing in BehaviorOphysDataset. Default = False (maintains current behavior by default)
* adds 'verbose' option to data_access.loading.get_ophys_data(). If False (now default), suppresses print statement during loading process.