### PR TITLE
updated test file path to work with windows and linux

### DIFF
--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -21,7 +21,7 @@ def test_find_nearest_index():
 
 @pytest.mark.skipif(not os.path.exists('//allen/programs/braintv'), reason="no access to network path, skipping test on network PKL files")
 def test_movie_load():
-    movie_path = "/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/test_fixtures/853773937_video-0.avi"
+    movie_path = "//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/test_fixtures/853773937_video-0.avi"
     movie = Movie(movie_path)
 
     # get frame by timestamp


### PR DESCRIPTION
updated filepath for test_movie_load in test_utilities to include double slash at beginning of filepath to work with windows and linux filepaths