### PR TITLE
Lims query changes

### DIFF
--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -58,7 +58,7 @@ def get_all_session_ids(ophys_experiment_id=None, ophys_session_id=None, behavio
         ophys_session_id {int} -- unique identifier for an ophys_session
         behavior_session_id {int} -- unique identifier for a behavior_session
         foraging_id {int} -- unique identifier for a behavior_session (1:1 with behavior session ID)
-        
+
     Only one experiment ID type should be passed
     Returns:
         dataframe with one column for each ID type (potentially multiple rows)
@@ -80,10 +80,10 @@ def get_all_session_ids(ophys_experiment_id=None, ophys_session_id=None, behavio
         search_key = 'foraging_id'
         id_to_search = "'{}'".format(foraging_id)
     lims_query = '''
-        select 
-            bs.id as behavior_session_id, 
-            bs.foraging_id as foraging_id, 
-            os.id as ophys_session_id, 
+        select
+            bs.id as behavior_session_id,
+            bs.foraging_id as foraging_id,
+            os.id as ophys_session_id,
             oe.id as ophys_experiment_id
         from behavior_sessions as bs
         join ophys_sessions as os on os.id = bs.ophys_session_id
@@ -119,7 +119,7 @@ def get_behavior_session_id_from_ophys_session_id(ophys_session_id, cache=None):
             from behavior_sessions as bs
             where bs.ophys_session_id = {}
         '''
-        return db.lims_query(lims_query_string.format(behavior_session_id)).astype(int)
+        return db.lims_query(lims_query_string.format(ophys_session_id)).astype(int)
 
 
 def get_ophys_session_id_from_behavior_session_id(behavior_session_id, cache=None):
@@ -315,8 +315,8 @@ def get_donor_id_from_specimen_id(specimen_id, cache=None):
     else:
         # if cache not passed, go to lims
         lims_query_string = '''
-            select donor_id 
-            from specimens 
+            select donor_id
+            from specimens
             where specimens.id = '{}'
         '''
         return db.lims_query(lims_query_string.format(specimen_id)).astype(int)

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -1,11 +1,8 @@
 import os
 import pandas as pd
 import json
-<<<<<<< HEAD
 import shutil
-=======
 import numpy as np
->>>>>>> d3fefa52... add options for lims queries in data_access.utilities
 from visual_behavior.data_access import loading
 from visual_behavior.ophys.io.lims_database import LimsDatabase
 from visual_behavior.ophys.sync.sync_dataset import Dataset as SyncDataset

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -85,11 +85,12 @@ def get_all_session_ids(ophys_experiment_id=None, ophys_session_id=None, behavio
             bs.foraging_id as foraging_id,
             os.id as ophys_session_id,
             oe.id as ophys_experiment_id,
-            oe.experiment_container_id as experiment_container_id,
+            oevbec.visual_behavior_experiment_container_id as container_id,
             os.visual_behavior_supercontainer_id as supercontainer_id
         from behavior_sessions as bs
         join ophys_sessions as os on os.id = bs.ophys_session_id
         join ophys_experiments as oe on os.id = oe.ophys_session_id
+        join ophys_experiments_visual_behavior_experiment_containers AS oevbec on oevbec.ophys_experiment_id=oe.id
         where {}.{} = {}
     '''
     return db.lims_query(lims_query.format(table, search_key, id_to_search))

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -1,7 +1,11 @@
 import os
 import pandas as pd
 import json
+<<<<<<< HEAD
 import shutil
+=======
+import numpy as np
+>>>>>>> d3fefa52... add options for lims queries in data_access.utilities
 from visual_behavior.data_access import loading
 from visual_behavior.ophys.io.lims_database import LimsDatabase
 from visual_behavior.ophys.sync.sync_dataset import Dataset as SyncDataset
@@ -49,8 +53,50 @@ def check_for_model_outputs(behavior_session_id):
     return len(model_output_file) > 0
 
 
-# retrieve data from cache
-def get_behavior_session_id_from_ophys_session_id(ophys_session_id, cache):
+def get_all_session_ids(ophys_experiment_id=None, ophys_session_id=None, behavior_session_id=None, foraging_id=None):
+    '''
+    a function to get all ID types for a given experiment ID
+    Arguments:
+        ophys_experiment_id {int} -- unique identifier for an ophys_experiment
+        ophys_session_id {int} -- unique identifier for an ophys_session
+        behavior_session_id {int} -- unique identifier for a behavior_session
+        foraging_id {int} -- unique identifier for a behavior_session (1:1 with behavior session ID)
+        
+    Only one experiment ID type should be passed
+    Returns:
+        dataframe with one column for each ID type (potentially multiple rows)
+    '''
+    if ophys_experiment_id:
+        table = 'oe'
+        search_key = 'id'
+        id_to_search = ophys_experiment_id
+    elif ophys_session_id:
+        table = 'os'
+        search_key = 'id'
+        id_to_search = ophys_session_id
+    elif behavior_session_id:
+        table = 'bs'
+        search_key = 'id'
+        id_to_search = behavior_session_id
+    elif foraging_id:
+        table = 'bs'
+        search_key = 'foraging_id'
+        id_to_search = "'{}'".format(foraging_id)
+    lims_query = '''
+        select 
+            bs.id as behavior_session_id, 
+            bs.foraging_id as foraging_id, 
+            os.id as ophys_session_id, 
+            oe.id as ophys_experiment_id
+        from behavior_sessions as bs
+        join ophys_sessions as os on os.id = bs.ophys_session_id
+        join ophys_experiments as oe on os.id = oe.ophys_session_id
+        where {}.{} = {}
+    '''
+    return db.lims_query(lims_query.format(table, search_key, id_to_search))
+
+
+def get_behavior_session_id_from_ophys_session_id(ophys_session_id, cache=None):
     """finds the behavior_session_id assocciated with an ophys_session_id
 
     Arguments:
@@ -64,18 +110,27 @@ def get_behavior_session_id_from_ophys_session_id(ophys_session_id, cache):
         int -- behavior_session_id : 9 digit, unique identifier for a
                 behavior_session
     """
-    ophys_sessions_table = cache.get_session_table()
-    if ophys_session_id not in ophys_sessions_table.index:
-        raise Exception('ophys_session_id not in session table')
-    return ophys_sessions_table.loc[ophys_session_id].behavior_session_id
+    if cache:
+        ophys_sessions_table = cache.get_session_table()
+        if ophys_session_id not in ophys_sessions_table.index:
+            raise Exception('ophys_session_id not in session table')
+        return ophys_sessions_table.loc[ophys_session_id].behavior_session_id
+    else:
+        # if cache not passed, go to lims
+        lims_query_string = '''
+            select bs.id
+            from behavior_sessions as bs
+            where bs.ophys_session_id = {}
+        '''
+        return db.lims_query(lims_query_string.format(behavior_session_id)).astype(int)
 
 
-def get_ophys_session_id_from_behavior_session_id(behavior_session_id, cache):
+def get_ophys_session_id_from_behavior_session_id(behavior_session_id, cache=None):
     """Finds the behavior_session_id associated with an ophys_session_id
 
     Arguments:
         behavior_session_id {int} -- 9 digit, unique identifier for a behavior_session
-        cache {object} -- cache from BehaviorProjectCache
+        cache {object} -- cache from BehaviorProjectCache (optional)
 
     Raises:
         Exception: [description]
@@ -83,13 +138,22 @@ def get_ophys_session_id_from_behavior_session_id(behavior_session_id, cache):
     Returns:
         int -- ophys_session_id: 9 digit, unique identifier for an ophys_session
     """
-    behavior_sessions = cache.get_behavior_session_table()
-    if behavior_session_id not in behavior_sessions.index:
-        raise Exception('behavior_session_id not in behavior session table')
-    return behavior_sessions.loc[behavior_session_id].ophys_session_id.astype(int)
+    if cache:
+        behavior_sessions = cache.get_behavior_session_table()
+        if behavior_session_id not in behavior_sessions.index:
+            raise Exception('behavior_session_id not in behavior session table')
+        return behavior_sessions.loc[behavior_session_id].ophys_session_id.astype(int)
+    else:
+        # if cache not passed, go to lims
+        lims_query_string = '''
+            select bs.ophys_session_id
+            from behavior_sessions as bs
+            where bs.id = {}
+        '''
+        return db.lims_query(lims_query_string.format(behavior_session_id)).astype(int)
 
 
-def get_ophys_experiment_id_from_behavior_session_id(behavior_session_id, cache, exp_num=0):
+def get_ophys_experiment_id_from_behavior_session_id(behavior_session_id, cache=None, exp_num=0):
     """Finds the ophys_experiment_id associated with an behavior_session_id. It is possible
     that there are multiple ophys_experiments for a single behavior session- as is the case
     for data collected on the multiscope microscopes
@@ -109,12 +173,28 @@ def get_ophys_experiment_id_from_behavior_session_id(behavior_session_id, cache,
         int -- ophys_experiment_id(s), 9 digit unique identifier for an ophys_experiment
                 possible that there are multip ophys_experiments for one behavior_session
     """
-    ophys_session_id = get_ophys_session_id_from_behavior_session_id(behavior_session_id, cache)
-    ophys_experiment_id = get_ophys_experiment_id_from_ophys_session_id(ophys_session_id, cache, exp_num=exp_num)
-    return ophys_experiment_id
+    if cache:
+        ophys_session_id = get_ophys_session_id_from_behavior_session_id(behavior_session_id, cache)
+        ophys_experiment_id = get_ophys_experiment_id_from_ophys_session_id(ophys_session_id, cache, exp_num=exp_num)
+        return ophys_experiment_id
+    else:
+        # if cache not passed, go to lims
+        lims_query_string = '''
+            select oe.id
+            from behavior_sessions as bs
+            join ophys_sessions as os on os.id = bs.ophys_session_id
+            join ophys_experiments as oe on os.id = oe.ophys_session_id
+            where bs.id = {}
+
+        '''
+        result = db.lims_query(lims_query_string.format(behavior_session_id))
+        if isinstance(result, (int, np.int64)):
+            return result.astype(int)
+        else:
+            return result['id'].astype(int).to_list()
 
 
-def get_ophys_experiment_id_from_ophys_session_id(ophys_session_id, cache, exp_num=0):
+def get_ophys_experiment_id_from_ophys_session_id(ophys_session_id, cache=None, exp_num=0):
     """finds the ophys_experiment_id associated with an ophys_session_id
 
     Arguments:
@@ -135,14 +215,29 @@ def get_ophys_experiment_id_from_ophys_session_id(ophys_session_id, cache, exp_n
         int -- ophys_experiment_id(s), 9 digit unique identifier for an ophys_experiment
         possible that there are multip ophys_experiments for one ophys_session
     """
-    ophys_sessions = cache.get_session_table()
-    if ophys_session_id not in ophys_sessions.index:
-        raise Exception('ophys_session_id not in session table')
-    experiments = ophys_sessions.loc[ophys_session_id].ophys_experiment_id
-    return experiments[0]
+    if cache:
+        ophys_sessions = cache.get_session_table()
+        if ophys_session_id not in ophys_sessions.index:
+            raise Exception('ophys_session_id not in session table')
+        experiments = ophys_sessions.loc[ophys_session_id].ophys_experiment_id
+        return experiments[0]
+    else:
+        # if cache not passed, go to lims
+        lims_query_string = '''
+            select oe.id
+            from ophys_sessions as os
+            join ophys_experiments as oe on os.id = oe.ophys_session_id
+            where os.id = {}
+
+        '''
+        result = db.lims_query(lims_query_string.format(ophys_session_id))
+        if isinstance(result, (int, np.int64)):
+            return result.astype(int)
+        else:
+            return result['id'].astype(int).to_list()
 
 
-def get_behavior_session_id_from_ophys_experiment_id(ophys_experiment_id, cache):
+def get_behavior_session_id_from_ophys_experiment_id(ophys_experiment_id, cache=None):
     """finds the behavior_session_id associated with an ophys_experiment_id
 
     Arguments:
@@ -155,13 +250,25 @@ def get_behavior_session_id_from_ophys_experiment_id(ophys_experiment_id, cache)
     Returns:
         int -- behavior_session_id, 9 digit, unique identifier for a behavior_session
     """
-    ophys_experiments = cache.get_experiment_table()
-    if ophys_experiment_id not in ophys_experiments.index:
-        raise Exception('ophys_experiment_id not in experiment table')
-    return ophys_experiments.loc[ophys_experiment_id].behavior_session_id
+    if cache:
+        ophys_experiments = cache.get_experiment_table()
+        if ophys_experiment_id not in ophys_experiments.index:
+            raise Exception('ophys_experiment_id not in experiment table')
+        return ophys_experiments.loc[ophys_experiment_id].behavior_session_id
+    else:
+        # if cache not passed, go to lims
+        lims_query_string = '''
+            select bs.id
+            from behavior_sessions as bs
+            join ophys_sessions as os on os.id = bs.ophys_session_id
+            join ophys_experiments as oe on os.id = oe.ophys_session_id
+            where oe.id = {}
+
+        '''
+        return db.lims_query(lims_query_string.format(ophys_experiment_id)).astype(int)
 
 
-def get_ophys_session_id_from_ophys_experiment_id(ophys_experiment_id, cache):
+def get_ophys_session_id_from_ophys_experiment_id(ophys_experiment_id, cache=None):
     """finds the ophys_session_id associated with an ophys_experiment_id
 
     Arguments:
@@ -174,14 +281,24 @@ def get_ophys_session_id_from_ophys_experiment_id(ophys_experiment_id, cache):
     Returns:
         int -- ophys_session_id: 9 digit, unique identifier for an ophys_session
     """
-    # cache = loading.get_visual_behavior_cache()
-    ophys_experiments = cache.get_experiment_table()
-    if ophys_experiment_id not in ophys_experiments.index:
-        raise Exception('ophys_experiment_id not in experiment table')
-    return ophys_experiments.loc[ophys_experiment_id].ophys_session_id
+    if cache:
+        ophys_experiments = cache.get_experiment_table()
+        if ophys_experiment_id not in ophys_experiments.index:
+            raise Exception('ophys_experiment_id not in experiment table')
+        return ophys_experiments.loc[ophys_experiment_id].ophys_session_id
+    else:
+        # if cache not passed, go to lims
+        lims_query_string = '''
+            select os.id
+            from ophys_sessions as os
+            join ophys_experiments as oe on os.id = oe.ophys_session_id
+            where oe.id = {}
+
+        '''
+        return db.lims_query(lims_query_string.format(ophys_experiment_id)).astype(int)
 
 
-def get_donor_id_from_specimen_id(specimen_id, cache):
+def get_donor_id_from_specimen_id(specimen_id, cache=None):
     """gets a donor_id associated with a specimen_id. Both donor_id
         and specimen_id are identifiers for a mouse.
 
@@ -192,11 +309,20 @@ def get_donor_id_from_specimen_id(specimen_id, cache):
     Returns:
         int -- donor id
     """
-    ophys_sessions = cache.get_session_table()
-    behavior_sessions = cache.get_behavior_session_table()
-    ophys_session_id = ophys_sessions.query('specimen_id == @specimen_id').iloc[0].name  # noqa: F841
-    donor_id = behavior_sessions.query('ophys_session_id ==@ophys_session_id')['donor_id'].values[0]
-    return donor_id
+    if cache:
+        ophys_sessions = cache.get_session_table()
+        behavior_sessions = cache.get_behavior_session_table()
+        ophys_session_id = ophys_sessions.query('specimen_id == @specimen_id').iloc[0].name  # noqa: F841
+        donor_id = behavior_sessions.query('ophys_session_id ==@ophys_session_id')['donor_id'].values[0]
+        return donor_id
+    else:
+        # if cache not passed, go to lims
+        lims_query_string = '''
+            select donor_id 
+            from specimens 
+            where specimens.id = '{}'
+        '''
+        return db.lims_query(lims_query_string.format(specimen_id)).astype(int)
 
 
 def model_outputs_available_for_behavior_session(behavior_session_id):

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -84,7 +84,9 @@ def get_all_session_ids(ophys_experiment_id=None, ophys_session_id=None, behavio
             bs.id as behavior_session_id,
             bs.foraging_id as foraging_id,
             os.id as ophys_session_id,
-            oe.id as ophys_experiment_id
+            oe.id as ophys_experiment_id,
+            oe.experiment_container_id as experiment_container_id,
+            os.visual_behavior_supercontainer_id as supercontainer_id
         from behavior_sessions as bs
         join ophys_sessions as os on os.id = bs.ophys_session_id
         join ophys_experiments as oe on os.id = oe.ophys_session_id

--- a/visual_behavior/database.py
+++ b/visual_behavior/database.py
@@ -190,12 +190,12 @@ def get_value_from_table(search_key, search_value, target_table, target_key):
     '''
     api = (credential_injector(LIMS_DB_CREDENTIAL_MAP)
            (PostgresQueryMixin)())
-    query = f'''
-    select {target_key}
-    from {target_table}
-    where {search_key} = '{search_value}'
+    query = '''
+        select {}
+        from {}
+        where {} = '{}'
     '''
-    result = pd.read_sql(query, api.get_connection())
+    result = pd.read_sql(query.format(target_key, target_table, search_key, search_value), api.get_connection())
     if len(result) == 1:
         return result[target_key].iloc[0]
     else:


### PR DESCRIPTION
* adds a new method to data_access.utilities which will query LIMS for all IDs given a single ID
Example use:

![image](https://user-images.githubusercontent.com/19944442/110038581-c2fa9a80-7cf4-11eb-8386-af0447d4a1b9.png)

* adds options to various data_access.utilities queries that allow them to work without passing a cache. Instead, they go straight to LIMS. This should make them more convenient for internal users.
* modifies the query format in a single method in database.py
