### PR TITLE
Add engagement to trials

### DIFF
--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -412,6 +412,7 @@ class BehaviorOphysDataset(BehaviorOphysExperiment):
         trials = reformat.add_epoch_times(trials)
         trials = reformat.add_trial_type_to_trials_table(trials)
         trials = reformat.add_reward_rate_to_trials_table(trials)
+        trials = reformat.add_engagement_state_to_trials_table(trials, self.extended_stimulus_presentations)
         self._extended_trials = trials
         return self._extended_trials
 
@@ -576,6 +577,7 @@ class BehaviorDataset(BehaviorSession):
         trials = reformat.add_epoch_times(trials)
         trials = reformat.add_trial_type_to_trials_table(trials)
         trials = reformat.add_reward_rate_to_trials_table(trials)
+        trials = reformat.add_engagement_state_to_trials_table(trials, self.extended_stimulus_presentations)
         self._extended_trials = trials
         return self._extended_trials
 

--- a/visual_behavior/data_access/reformat.py
+++ b/visual_behavior/data_access/reformat.py
@@ -70,13 +70,13 @@ def add_engagement_state_to_trials_table(trials, extended_stimulus_presentations
 
     # define the columns from extended_stimulus_presentations that we want to merge into trials
     cols_to_merge = [
-        'engaged', 
+        'engaged',
         'engagement_state'
     ]
 
     # merge the desired columns into trials on the stimulus_presentations_id indices
     trials = trials = trials.merge(
-        extended_stimulus_presentations[].reset_index(),
+        extended_stimulus_presentations[cols_to_merge].reset_index(),
         left_on='first_stim_presentation_index',
         right_on='stimulus_presentations_id',
     )

--- a/visual_behavior/data_access/reformat.py
+++ b/visual_behavior/data_access/reformat.py
@@ -56,15 +56,20 @@ def add_engagement_state_to_trials_table(trials, extended_stimulus_presentations
     '''
     extended_stimulus_presentations = extended_stimulus_presentations
 
-    for idx,trial in trials.iterrows():
+    for idx, trial in trials.iterrows():
         start_time = trial['start_time']
-        first_stim_presentation_index = np.argmin(np.abs(start_time - extended_stimulus_presentations.query('start_time > @start_time - 1 and start_time < @start_time + 1')['start_time']))
+        query_string = 'start_time > @start_time - 1 and start_time < @start_time + 1'
+        first_stim_presentation_index = np.argmin(
+            np.abs(
+                start_time - extended_stimulus_presentations.query(query_string)['start_time']
+            )
+        )
         trials.at[idx, 'first_stim_presentation_index'] = first_stim_presentation_index
 
     trials = trials = trials.merge(
-        extended_stimulus_presentations[['engaged','engagement_state']].reset_index(),
-        left_on = 'first_stim_presentation_index',
-        right_on = 'stimulus_presentations_id',
+        extended_stimulus_presentations[['engaged', 'engagement_state']].reset_index(),
+        left_on='first_stim_presentation_index',
+        right_on='stimulus_presentations_id',
     )
 
     return trials

--- a/visual_behavior/data_access/reformat.py
+++ b/visual_behavior/data_access/reformat.py
@@ -56,6 +56,8 @@ def add_engagement_state_to_trials_table(trials, extended_stimulus_presentations
     '''
     extended_stimulus_presentations = extended_stimulus_presentations
 
+    # for each trial, find the stimulus index that is closest to the trial start
+    # add to a new column called 'first_stim_presentation_index'
     for idx, trial in trials.iterrows():
         start_time = trial['start_time']
         query_string = 'start_time > @start_time - 1 and start_time < @start_time + 1'
@@ -66,8 +68,15 @@ def add_engagement_state_to_trials_table(trials, extended_stimulus_presentations
         )
         trials.at[idx, 'first_stim_presentation_index'] = first_stim_presentation_index
 
+    # define the columns from extended_stimulus_presentations that we want to merge into trials
+    cols_to_merge = [
+        'engaged', 
+        'engagement_state'
+    ]
+
+    # merge the desired columns into trials on the stimulus_presentations_id indices
     trials = trials = trials.merge(
-        extended_stimulus_presentations[['engaged', 'engagement_state']].reset_index(),
+        extended_stimulus_presentations[].reset_index(),
         left_on='first_stim_presentation_index',
         right_on='stimulus_presentations_id',
     )


### PR DESCRIPTION
Add's columns for `engaged` (bool) and `engagement_state` (str, 'engaged' or 'disengaged') to the `extended_trials` table.

Example use:

```
from visual_behavior.data_access import loading

oeid = 958527474

dataset = loading.get_ophys_dataset(oeid)

dataset.extended_trials
```

The value of  `engaged` and `engagement_state` is taken from the stimulus in `extended_stimulus_presentations` that most closely aligns with the `start_time` of each trial.

Given that `extended_stimulus_presentations` must first be built, this function is slow.