### PR TITLE
changing csv to pkl

### DIFF
--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -752,9 +752,7 @@ def add_model_outputs_to_stimulus_presentations(stimulus_presentations, behavior
         stimulus_presentations = stimulus_presentations.merge(model_outputs, right_on='stimulus_presentations_id',
                                                               left_on='stimulus_presentations_id').set_index(
             'stimulus_presentations_id')
-        stimulus_presentations['engagement_state'] = [
-            'engaged' if flash_metrics_label != 'low-lick,low-reward' else 'disengaged' for flash_metrics_label in
-            stimulus_presentations.flash_metrics_labels.values]
+        stimulus_presentations['engagement_state'] = ['engaged' if x else 'disengaged' for x in stimulus_presentations['engaged']]
         stimulus_presentations = stimulus_presentations.drop(
             columns=['hit_rate', 'miss_rate', 'false_alarm_rate', 'correct_reject_rate', 'd_prime', 'criterion'])
         return stimulus_presentations

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -765,7 +765,7 @@ def add_model_outputs_to_stimulus_presentations(stimulus_presentations, behavior
 
 def get_behavior_model_summary_table():
     data_dir = get_behavior_model_outputs_dir()
-    data = pd.read_csv(os.path.join(data_dir, '_summary_table.csv'))
+    data = pd.read_pkl(os.path.join(data_dir, '_summary_table.pkl'))
     return data
 
 


### PR DESCRIPTION
I moved from a csv file to a .pkl file for the summary table because I now include several columns that are arrays. These metrics don't load properly from csv. They include:
- the model weights
- image by image metrics like CR (every non change image without a lick), miss (change without lick), hit (change with a lick), FA (every non-change image with a lick). 
- image by image response time metric. This is bounded between (0, 750ms), and is the time between the start of each lick bout to the most recent image start. 
- image by image engaged/disengaged metric
- lick_bout_start (did a lick bout start during this image presentation?)
- lick_bout_rate (lick bouts/sec, averaged over 320 seconds)
- reward_rate (rewards/sec, averaged over 320 seconds)
- change (was this image a change image)
- lick_hit_fraction_rate (fraction of lick bouts that result in a reward

For all of these array columns, I clean the entries such that they are exactly 4800 entries long. Sessions sometimes have more or less, and those values get truncated, or filled with NaNs so everything is exactly the same length. This standardization makes it easy to do things like:
`weights_for_all_sessions = np.vstack(summary_table['weight_bias'].values)`

I also now include several new columns
- strategy_matched (True marks a subset of sessions to include in a strategy matched subset across cre-lines)
- the average value of several metrics on just the engaged/disengaged images

In addition, I removed the old references to high/low lick and reward rate, and updated the engagement metric to use reward rate above 1/90 rewards/second. 

I don't know how people have been using the summary table, so I'm not sure if there is anything else that needs to be changed. 