### PR TITLE
bugfixes in add_engagement_state_to_trials_table

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[metadata]
+git [metadata]
 name = visual-behavior
 version = 0.12.0
 description = "analysis package for visual behavior"
@@ -18,6 +18,7 @@ install_requires =
 	opencv-python
 	dash
 	plotly
+	hdmf<=2.4.0
 
 [options.extras_require]
 DEV =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-git [metadata]
+[metadata]
 name = visual-behavior
 version = 0.12.0
 description = "analysis package for visual behavior"

--- a/tests/data_access/test_reformat.py
+++ b/tests/data_access/test_reformat.py
@@ -1,0 +1,48 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from visual_behavior.data_access.reformat import add_engagement_state_to_trials_table
+
+def test_add_engagement_state_to_trials_table():
+    extended_stimulus_presentations = pd.DataFrame(
+        [
+            {'stimulus_presentations_id': 188, 'start_time': 450.40741, 'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 189, 'start_time': 451.15798, 'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 190, 'start_time': 451.90859, 'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 191, 'start_time': 452.65921, 'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 192, 'start_time': 453.40984, 'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 193, 'start_time': 454.16046, 'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 194, 'start_time': 454.91107, 'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 195, 'start_time': 455.66172, 'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 196, 'start_time': 456.4123,  'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 197, 'start_time': 457.16291, 'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 198, 'start_time': 457.91351, 'engaged': False, 'engagement_state': 'disengaged'},
+            {'stimulus_presentations_id': 199, 'start_time': 458.66411, 'engaged': True, 'engagement_state': 'engaged'},
+            {'stimulus_presentations_id': 200, 'start_time': 459.41474, 'engaged': True, 'engagement_state': 'engaged'},
+            {'stimulus_presentations_id': 201, 'start_time': 460.16537, 'engaged': True, 'engagement_state': 'engaged'},
+            {'stimulus_presentations_id': 202, 'start_time': 460.916, 'engaged': True, 'engagement_state': 'engaged'},
+            {'stimulus_presentations_id': 203, 'start_time': 461.66659, 'engaged': True, 'engagement_state': 'engaged'},
+            {'stimulus_presentations_id': 204, 'start_time': 462.4172, 'engaged': True, 'engagement_state': 'engaged'},
+            {'stimulus_presentations_id': 205, 'start_time': 463.16782, 'engaged': True, 'engagement_state': 'engaged'},
+            {'stimulus_presentations_id': 206, 'start_time': 463.91841, 'engaged': True, 'engagement_state': 'engaged'},
+            {'stimulus_presentations_id': 207, 'start_time': 464.66905, 'engaged': True, 'engagement_state': 'engaged'}
+        ]
+    ).set_index('stimulus_presentations_id')
+
+    trials = pd.DataFrame(
+        [
+            {'start_time': 451.14132},
+            {'start_time': 459.39807},
+            {'start_time': 461.64992}
+        ]
+    )
+    
+    expected_result = pd.DataFrame([
+        {'start_time': 451.14132, 'first_stim_presentation_index': 189.0, 'stimulus_presentations_id': 189, 'engaged': False, 'engagement_state': 'disengaged'},
+        {'start_time': 459.39807, 'first_stim_presentation_index': 200.0, 'stimulus_presentations_id': 200, 'engaged': True, 'engagement_state': 'engaged'},
+        {'start_time': 461.64992, 'first_stim_presentation_index': 203.0, 'stimulus_presentations_id': 203, 'engaged': True, 'engagement_state': 'engaged'}
+    ])
+    
+    assert_frame_equal(
+        expected_result,
+        add_engagement_state_to_trials_table(trials, extended_stimulus_presentations)
+    )

--- a/visual_behavior/data_access/reformat.py
+++ b/visual_behavior/data_access/reformat.py
@@ -61,11 +61,7 @@ def add_engagement_state_to_trials_table(trials, extended_stimulus_presentations
     for idx, trial in trials.iterrows():
         start_time = trial['start_time']
         query_string = 'start_time > @start_time - 1 and start_time < @start_time + 1'
-        first_stim_presentation_index = np.argmin(
-            np.abs(
-                start_time - extended_stimulus_presentations.query(query_string)['start_time']
-            )
-        )
+        first_stim_presentation_index = (np.abs(start_time - extended_stimulus_presentations.query(query_string)['start_time'])).idxmin()
         trials.at[idx, 'first_stim_presentation_index'] = first_stim_presentation_index
 
     # define the columns from extended_stimulus_presentations that we want to merge into trials
@@ -75,7 +71,7 @@ def add_engagement_state_to_trials_table(trials, extended_stimulus_presentations
     ]
 
     # merge the desired columns into trials on the stimulus_presentations_id indices
-    trials = trials = trials.merge(
+    trials = trials.merge(
         extended_stimulus_presentations[cols_to_merge].reset_index(),
         left_on='first_stim_presentation_index',
         right_on='stimulus_presentations_id',


### PR DESCRIPTION
fixes two bugs in `visual_behavior.data_access.reformat.add_engagement_state_to_trials_table`

1) replaces `np.argmin` with `pd.idxmin`: argmin worked when I developed the function, but has suddenly stopped working. I changed my pandas version, which might explain why. Regardless, idxmin should be more reliable

2) fixed double assignment

Also adds a test on `visual_behavior.data_access.reformat.add_engagement_state_to_trials_table`. 

Pinning hdmf at 2.4.0 to deal with this issue:
https://github.com/AllenInstitute/AllenSDK/issues/2098