### PR TITLE
fix broken experiment_id to session_id code and limit stdout warnings/prints

### DIFF
--- a/visual_behavior/data_access/from_lims.py
+++ b/visual_behavior/data_access/from_lims.py
@@ -36,8 +36,6 @@ except Exception as e:
     warnings.warn(warn_string)
 
 
-
-
 ### QUERIES USED FOR MULTIPLE FUNCTIONS ###      # noqa: E266
 def general_info_for_id_query():
     """the base query used for all the 'get_general_info_for...

--- a/visual_behavior/data_access/from_lims.py
+++ b/visual_behavior/data_access/from_lims.py
@@ -23,7 +23,11 @@ try:
         user=lims_user,
         host=lims_host,
         password=lims_password,
-        port=lims_port)
+        port=lims_port
+    )
+
+    # building querys
+    mixin = lims_engine
 
 except Exception as e:
     warn_string = 'failed to set up LIMS/mtrain credentials\n{}\n\n \
@@ -31,8 +35,7 @@ except Exception as e:
         appropriately\nfunctions requiring database access will fail'.format(e)
     warnings.warn(warn_string)
 
-# building querys
-mixin = lims_engine
+
 
 
 ### QUERIES USED FOR MULTIPLE FUNCTIONS ###      # noqa: E266

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -480,7 +480,7 @@ def get_ophys_dataset(ophys_experiment_id, include_invalid_rois=False, from_lims
         object -- BehaviorOphysSession or BehaviorOphysDataset instance, which inherits attributes & methods from SDK BehaviorOphysSession
     """
     if from_lims:
-        dataset = BehaviorOphysExperiment.from_lims(ophys_experiment_id)
+        dataset = BehaviorOphysExperiment.from_lims(int(ophys_experiment_id))
     elif from_nwb:
         nwb_files = get_release_ophys_nwb_file_paths()
         nwb_file = [file for file in nwb_files.nwb_file.values if str(ophys_experiment_id) in file]
@@ -492,7 +492,7 @@ def get_ophys_dataset(ophys_experiment_id, include_invalid_rois=False, from_lims
         else:
             print('no NWB file path found for', ophys_experiment_id)
     else:
-        api = BehaviorOphysLimsApi(ophys_experiment_id)
+        api = BehaviorOphysLimsApi(int(ophys_experiment_id))
         dataset = BehaviorOphysDataset(api, include_invalid_rois)
     return dataset
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -8,6 +8,7 @@ from allensdk.brain_observatory.behavior.behavior_project_cache import VisualBeh
 from visual_behavior.data_access import filtering
 from visual_behavior.data_access import reformat
 from visual_behavior.data_access import utilities
+from visual_behavior.data_access import from_lims
 import visual_behavior.database as db
 
 import os
@@ -425,22 +426,19 @@ class BehaviorOphysDataset(BehaviorOphysExperiment):
 
     @property
     def behavior_movie_pc_masks(self):
-        cache = get_visual_behavior_cache()
-        ophys_session_id = utilities.get_ophys_session_id_from_ophys_experiment_id(self.ophys_experiment_id, cache)
+        ophys_session_id = from_lims.get_ophys_session_id_for_ophys_experiment_id(self.ophys_experiment_id)
         self._behavior_movie_pc_masks = get_pc_masks_for_session(ophys_session_id)
         return self._behavior_movie_pc_masks
 
     @property
     def behavior_movie_pc_activations(self):
-        cache = get_visual_behavior_cache()
-        ophys_session_id = utilities.get_ophys_session_id_from_ophys_experiment_id(self.ophys_experiment_id, cache)
+        ophys_session_id = from_lims.get_ophys_session_id_for_ophys_experiment_id(self.ophys_experiment_id)
         self._behavior_movie_pc_activations = get_pc_activations_for_session(ophys_session_id)
         return self._behavior_movie_pc_activations
 
     @property
     def behavior_movie_predictions(self):
-        cache = get_visual_behavior_cache()
-        ophys_session_id = utilities.get_ophys_session_id_from_ophys_experiment_id(self.ophys_experiment_id, cache)
+        ophys_session_id = from_lims.get_ophys_session_id_for_ophys_experiment_id(self.ophys_experiment_id)
         movie_predictions = get_behavior_movie_predictions_for_session(ophys_session_id)
         movie_predictions.index.name = 'frame_index'
         movie_predictions['timestamps'] = self.behavior_movie_timestamps[:len(
@@ -1438,7 +1436,6 @@ def get_average_depth_image(experiment_id):
     session_dir = utilities.get_ophys_session_dir(utilities.get_lims_data(experiment_id))
     experiment_table = get_filtered_ophys_experiment_table(include_failed_data=True)
     session_id = experiment_table.loc[experiment_id].ophys_session_id
-    # session_id = utilities.get_ophys_session_id_from_ophys_experiment_id(experiment_id, cache)
 
     # try all combinations of potential file path locations...
     if os.path.isfile(os.path.join(session_dir, str(experiment_id) + '_averaged_depth.tif')):

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -385,7 +385,7 @@ def get_ssim(img0, img1):
 
 
 def get_lims_data(lims_id):
-    ld = LimsDatabase(lims_id)
+    ld = LimsDatabase(int(lims_id))
     lims_data = ld.get_qc_param()
     lims_data.insert(loc=2, column='experiment_id', value=lims_data.lims_id.values[0])
     lims_data.insert(loc=2, column='session_type',
@@ -491,7 +491,6 @@ def get_sync_data(lims_data, use_acq_trigger):
         frames_2p = frames_2p[frames_2p > trigger[0]]
     # print(len(frames_2p))
     if lims_data.rig.values[0][0] == 'M':  # if Mesoscope
-        print('resampling mesoscope 2P frame times')
         roi_group = get_roi_group(lims_data)  # get roi_group order
         frames_2p = frames_2p[roi_group::4]  # resample sync times
     # print(len(frames_2p))

--- a/visual_behavior/ophys/sync/process_sync.py
+++ b/visual_behavior/ophys/sync/process_sync.py
@@ -31,7 +31,7 @@ def filter_digital(rising, falling, threshold=0.0001):
     return rising_f, falling_f
 
 
-def calculate_delay(sync_data, stim_vsync_fall, sample_frequency):
+def calculate_delay(sync_data, stim_vsync_fall, sample_frequency, verbose=False):
     # from http://stash.corp.alleninstitute.org/projects/INF/repos/lims2_modules/browse/CAM/ophys_time_sync/ophys_time_sync.py
     ASSUMED_DELAY = 0.0351
     DELAY_THRESHOLD = 0.001
@@ -111,7 +111,8 @@ def calculate_delay(sync_data, stim_vsync_fall, sample_frequency):
 
             if (delay > DELAY_THRESHOLD or np.isnan(delay)):
                 delay = ASSUMED_DELAY
-                logger.error("Sync photodiode error needs to be fixed. Using assumed monitor delay: {}".format(round(delay, ROUND_PRECISION)))
+                if verbose:
+                    logger.error("Sync photodiode error needs to be fixed. Using assumed monitor delay: {}".format(round(delay, ROUND_PRECISION)))
 
         # assume delay
         else:
@@ -119,6 +120,7 @@ def calculate_delay(sync_data, stim_vsync_fall, sample_frequency):
     except Exception as e:
         logger.info(e)
         delay = ASSUMED_DELAY
-        logger.error("Process without photodiode signal. Assumed delay: {}".format(round(delay, ROUND_PRECISION)))
+        if verbose:
+            logger.error("Process without photodiode signal. Assumed delay: {}".format(round(delay, ROUND_PRECISION)))
 
     return delay


### PR DESCRIPTION
Updates lines of code in data_access.loading to use updated code in data_access.from_lims to convert ophys_experiment_id top ophys_session_id.

Fixes issue #747.

Also maybe related to this issue in the GLM:
AllenInstitute/visual_behavior_glm#247

Also fixes issue #750:
Removes unnecessary print statement in data_access.utilities that said `resampling mesoscope 2P frame times` and casts experiment_id to int to avoid warnings about numpy.int64 type in LIMS queries.

And also fixes issue #751: makes sync photodiode error printout optional (suppressed by default). Since the display lag is now being calculated by the SDK, I don't think that it's important for VBA to be reporting problems now.