### PR TITLE
adding function to get cell_specimen table from LIMS

### DIFF
--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -2745,7 +2745,7 @@ def get_cell_table(ophys_session_ids=None, columns_to_return='*'):
         ophys_session_ids = experiment_table['ophys_experiment_id'].unique()
 
     if columns_to_return != '*':
-        columns_to_return = ', '.join(columns_to_return)
+        columns_to_return = ', '.join(columns_to_return).replace('cell_roi_id', 'id')
 
     query = '''
         select {}

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -2672,3 +2672,90 @@ def get_remaining_crosstalk_amount_dict(experiment_id):
         remaining_crosstalk_dict[int(key)] = crosstalk_dict[key][1]
 
     return remaining_crosstalk_dict
+
+
+def get_cell_table(ophys_session_ids=None, columns_to_return='*'):
+    '''
+    retrieves the full cell_specimen table from LIMS for the specified ophys_experiment_ids
+    if no ophys_experiment_ids are passed, all experiments from the `VisualBehaviorOphysProjectCache` will be retrieved
+
+    Parameters
+    ----------
+    ophys_session_ids : list
+        A list of ophys_experiment_ids for which to retrieve the associated cells.
+        If None, all experiments from the `VisualBehaviorOphysProjectCache` will be retrieved.
+        Default = None
+    columns_to_return
+        A list of which colums to return.
+        If "*" is passed, all columns will be returned.
+        Queries will be faster if fewer columns are returned.
+        Possible columns that can be returned:
+            cell_roi_id
+            cell_specimen_id
+            ophys_experiment_id
+            x
+            y
+            width
+            height
+            valid_roi
+            mask_matrix
+            max_correction_up
+            max_correction_down
+            max_correction_right
+            max_correction_left
+            mask_image_plane
+            ophys_cell_segmentation_run_id
+        default = '*'
+
+    Returns
+    -------
+    pandas.DataFrame
+        A dataframe with one row per cell and each of the requested columns
+
+
+    Examples:
+    -------
+    This will return all columns for all released experiments
+    This takes about 5 seconds
+    >> cell_table = get_cell_table()
+
+    This will return only the columns ['ophys_experiment_id','cell_specimen_id'] for all released experiments
+    This takes about 1.5 seconds
+    >> get_cell_table(columns_to_return = ['ophys_experiment_id','cell_specimen_id'])
+
+    This will return only the columns ['ophys_experiment_id','cell_specimen_id'] for the specified experiments
+    This takes about 20 ms
+    >> oeids = [792813858, 888876943, 986518885, 942596355, 908381680]
+    >> cell_table = get_cell_table(ophys_session_ids = oeids, columns_to_return = ['ophys_experiment_id','cell_specimen_id'])
+
+    This will return all columns for the specified experiments
+    This takes about 50 ms
+    >> oeids = [792813858, 888876943, 986518885, 942596355, 908381680]
+    >> cell_table = get_cell_table(ophys_session_ids = oeids)
+
+
+    '''
+    # get ophys_session_ids from S3 if they were not passed
+    if ophys_session_ids is None:
+        data_storage_directory = '/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/production_cache'
+        cache = bpc.from_s3_cache(cache_dir=data_storage_directory)
+
+        experiment_table = cache.get_ophys_experiment_table().reset_index()
+
+        ophys_session_ids = experiment_table['ophys_experiment_id'].unique()
+
+    if columns_to_return != '*':
+        columns_to_return = ', '.join(columns_to_return)
+
+    query = '''
+        select {}
+        from cell_rois
+        where ophys_experiment_id in {} and cell_specimen_id is not null and valid_roi = True
+    '''
+
+    # Since we are querying from the 'cell_rois' table, the 'id' column is actually 'cell_roi_id'. Rename.
+    lims_rois = db.lims_query(
+        query.format(columns_to_return, tuple(ophys_session_ids))
+    ).rename(columns={'id': 'cell_roi_id'})
+
+    return lims_rois


### PR DESCRIPTION
Adds a function to data_access/loading called `get_cell_table` that will return data from the LIMS `cell_rois` table for specified experiments. If no experiments are passed, it returns all released cells.

Details and examples in the docstring.