### PR TITLE
Break out behavior model function

### DIFF
--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -762,7 +762,7 @@ def check_if_model_output_available(behavior_session_id):
         return False
 
 
-def load_model_outputs(behavior_session_id):
+def load_behavior_model_outputs(behavior_session_id):
     '''
     loads the behavior model outputs from their default save location on the /allen filesystem
 
@@ -777,17 +777,44 @@ def load_model_outputs(behavior_session_id):
         dataframe containing behavior model outputs
     '''
 
+    # cast ID to int
+    behavior_session_id = int(behavior_session_id)
+
+    if check_if_model_output_available(behavior_session_id):
+        model_outputs = pd.read_csv(
+            os.path.join(
+                get_behavior_model_outputs_dir(),
+                get_model_output_file(behavior_session_id)[0]
+            )
+        )
+        cols_to_drop = [
+            'image_index',
+            'image_name',
+            'omitted',
+            'change',
+            'licked',
+            'lick_rate',
+            'rewarded',
+            'reward_rate',
+            'is_change'
+        ]
+        model_outputs.drop(columns=cols_to_drop, inplace=True)
+
+    else:
+        warnings.warn('no model outputs saved for behavior_session_id: {}'.format(behavior_session_id))
+        model_outputs = None
+
+    return model_outputs
+
 
 def add_model_outputs_to_stimulus_presentations(stimulus_presentations, behavior_session_id):
     '''
        Adds additional columns to stimulus table for model weights and related metrics
     '''
 
-    if check_if_model_output_available(behavior_session_id):
-        model_outputs = pd.read_csv(
-            os.path.join(get_behavior_model_outputs_dir(), get_model_output_file(behavior_session_id)[0]))
-        model_outputs.drop(columns=['image_index', 'image_name', 'omitted', 'change',
-                                    'licked', 'lick_rate', 'rewarded', 'reward_rate', 'is_change'], inplace=True)
+    model_outputs = load_behavior_model_outputs(behavior_session_id)
+
+    if model_outputs is not None:
         stimulus_presentations = stimulus_presentations.merge(model_outputs, right_on='stimulus_presentations_id',
                                                               left_on='stimulus_presentations_id').set_index(
             'stimulus_presentations_id')
@@ -795,8 +822,7 @@ def add_model_outputs_to_stimulus_presentations(stimulus_presentations, behavior
         stimulus_presentations = stimulus_presentations.drop(
             columns=['hit_rate', 'miss_rate', 'false_alarm_rate', 'correct_reject_rate', 'd_prime', 'criterion'])
         return stimulus_presentations
-    else:
-        print('no model outputs saved for behavior_session_id:', behavior_session_id)
+
     return stimulus_presentations
 
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -780,6 +780,10 @@ def load_behavior_model_outputs(behavior_session_id):
     # cast ID to int
     behavior_session_id = int(behavior_session_id)
 
+    # check ID type to ensure that it is a behavior_session_id
+    id_type = from_lims.get_id_type(behavior_session_id)
+    assert id_type == 'behavior_session_id', "passed ID must be a behavior_session_id. A {} was passed instead".format(id_type)
+
     if check_if_model_output_available(behavior_session_id):
         model_outputs = pd.read_csv(
             os.path.join(

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -762,6 +762,22 @@ def check_if_model_output_available(behavior_session_id):
         return False
 
 
+def load_model_outputs(behavior_session_id):
+    '''
+    loads the behavior model outputs from their default save location on the /allen filesystem
+
+    Parameters:
+    -----------
+    behavior_session_id : int
+        desired behavior session ID
+
+    Returns:
+    --------
+    Pandas.DataFrame
+        dataframe containing behavior model outputs
+    '''
+
+
 def add_model_outputs_to_stimulus_presentations(stimulus_presentations, behavior_session_id):
     '''
        Adds additional columns to stimulus table for model weights and related metrics


### PR DESCRIPTION
This PR breaks `load_behavior_model_outputs` into a distinct function in data_access.loading.

Making this function available on its own facilitates loading just the model outputs if desired.

The `add_model_outputs_to_stimulus_presentations` function now uses `load_behavior_model_outputs`