### PR TITLE
update input param name to get_cell_tabe

### DIFF
--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -2829,14 +2829,14 @@ def get_remaining_crosstalk_amount_dict(experiment_id):
     return remaining_crosstalk_dict
 
 
-def get_cell_table(ophys_session_ids=None, columns_to_return='*'):
+def get_cell_table(ophys_experiment_ids=None, columns_to_return='*'):
     '''
     retrieves the full cell_specimen table from LIMS for the specified ophys_experiment_ids
     if no ophys_experiment_ids are passed, all experiments from the `VisualBehaviorOphysProjectCache` will be retrieved
 
     Parameters
     ----------
-    ophys_session_ids : list
+    ophys_experiment_ids : list
         A list of ophys_experiment_ids for which to retrieve the associated cells.
         If None, all experiments from the `VisualBehaviorOphysProjectCache` will be retrieved.
         Default = None
@@ -2890,9 +2890,9 @@ def get_cell_table(ophys_session_ids=None, columns_to_return='*'):
 
 
     '''
-    # get ophys_session_ids from S3 if they were not passed
-    if ophys_session_ids is None:
-        data_storage_directory = '/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/production_cache'
+    # get ophys_experiment_ids from S3 if they were not passed
+    if ophys_experiment_ids is None:
+        data_storage_directory = get_cache_dir()
         cache = bpc.from_s3_cache(cache_dir=data_storage_directory)
 
         experiment_table = cache.get_ophys_experiment_table().reset_index()
@@ -2910,7 +2910,7 @@ def get_cell_table(ophys_session_ids=None, columns_to_return='*'):
 
     # Since we are querying from the 'cell_rois' table, the 'id' column is actually 'cell_roi_id'. Rename.
     lims_rois = db.lims_query(
-        query.format(columns_to_return, tuple(ophys_session_ids))
+        query.format(columns_to_return, tuple(ophys_experiment_ids))
     ).rename(columns={'id': 'cell_roi_id'})
 
     return lims_rois

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -2895,9 +2895,9 @@ def get_cell_table(ophys_experiment_ids=None, columns_to_return='*'):
         data_storage_directory = get_cache_dir()
         cache = bpc.from_s3_cache(cache_dir=data_storage_directory)
 
-        experiment_table = cache.get_ophys_experiment_table().reset_index()
+        experiment_table = cache.get_ophys_experiment_table()
 
-        ophys_session_ids = experiment_table['ophys_experiment_id'].unique()
+        ophys_experiment_ids = experiment_table.index.unique()
 
     if columns_to_return != '*':
         columns_to_return = ', '.join(columns_to_return).replace('cell_roi_id', 'id')


### PR DESCRIPTION
the get_cell_table function has ophys_session_ids as an input param when it really wants ophys_experiment_ids. this PR fixes that. 