### PR TITLE
removing outdated SDK classes

### DIFF
--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -573,7 +573,7 @@ def get_ophys_dataset(ophys_experiment_id, include_invalid_rois=False, load_from
         load_from_lims -- if True, loads dataset directly from BehaviorOphysSession.from_lims(). Invalid ROIs will be included.
         load_from_nwb -- if True, loads dataset directly from BehaviorOphysSession.from_nwb_path(). Invalid ROIs will not be included.
 
-        If both from_lims and from_nwb are set to False, an exception will be raised 
+        If both from_lims and from_nwb are set to False, an exception will be raised
 
     Returns:
         object -- BehaviorOphysSession or BehaviorOphysDataset instance, which inherits attributes & methods from SDK BehaviorOphysSession
@@ -695,7 +695,7 @@ def get_behavior_dataset(behavior_session_id, from_lims=False, from_nwb=False):
         from_lims -- if True, loads dataset directly from BehaviorSession.from_lims()
         from_nwb -- if True, loads dataset directly from BehaviorSession.from_nwb_path(), after converting behavior_session_id to nwb_path via lims query
 
-        If both from_lims and from_nwb are set to False, an exception will be raised 
+        If both from_lims and from_nwb are set to False, an exception will be raised
 
     Returns:
         object -- BehaviorSession or BehaviorDataset instance

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -1,8 +1,6 @@
 import warnings
 from allensdk.internal.api import PostgresQueryMixin
-from allensdk.brain_observatory.behavior.session_apis.data_io import BehaviorLimsApi
 from allensdk.brain_observatory.behavior.behavior_session import BehaviorSession
-from allensdk.brain_observatory.behavior.session_apis.data_io import BehaviorOphysLimsApi
 from allensdk.brain_observatory.behavior.behavior_ophys_experiment import BehaviorOphysExperiment
 from allensdk.brain_observatory.behavior.behavior_project_cache import VisualBehaviorOphysProjectCache as bpc
 from visual_behavior.data_access import filtering
@@ -575,7 +573,7 @@ def get_ophys_dataset(ophys_experiment_id, include_invalid_rois=False, load_from
         load_from_lims -- if True, loads dataset directly from BehaviorOphysSession.from_lims(). Invalid ROIs will be included.
         load_from_nwb -- if True, loads dataset directly from BehaviorOphysSession.from_nwb_path(). Invalid ROIs will not be included.
 
-        If both from_lims and from_nwb are set to False, data will be loaded using the LIMS API then passed to the BehaviorOphysDataset class which allows invalid ROIs to be filtered out, and allows access to extended_stimulus_presentations, and face movie data.
+        If both from_lims and from_nwb are set to False, an exception will be raised 
 
     Returns:
         object -- BehaviorOphysSession or BehaviorOphysDataset instance, which inherits attributes & methods from SDK BehaviorOphysSession
@@ -600,8 +598,7 @@ def get_ophys_dataset(ophys_experiment_id, include_invalid_rois=False, load_from
         else:
             print('no NWB file path found for', ophys_experiment_id)
     else:
-        api = BehaviorOphysLimsApi(int(ophys_experiment_id))
-        dataset = BehaviorOphysDataset(api, include_invalid_rois)
+        raise Exception('Set load_from_lims or load_from_nwb to True')
     return dataset
 
 
@@ -698,7 +695,7 @@ def get_behavior_dataset(behavior_session_id, from_lims=False, from_nwb=False):
         from_lims -- if True, loads dataset directly from BehaviorSession.from_lims()
         from_nwb -- if True, loads dataset directly from BehaviorSession.from_nwb_path(), after converting behavior_session_id to nwb_path via lims query
 
-        If both from_lims and from_nwb are set to False, data will be loaded using the LIMS API then passed to the BehaviorDataset class which allows access to extended_stimulus_presentations and trials.
+        If both from_lims and from_nwb are set to False, an exception will be raised 
 
     Returns:
         object -- BehaviorSession or BehaviorDataset instance
@@ -715,8 +712,7 @@ def get_behavior_dataset(behavior_session_id, from_lims=False, from_nwb=False):
         else:
             print('no NWB file path found for', behavior_session_id)
     else:
-        api = BehaviorLimsApi(behavior_session_id)
-        dataset = BehaviorDataset(api)
+        raise Exception('Set load_from_lims or load_from_nwb to True')
     return dataset
 
 


### PR DESCRIPTION
`data_access/loading.py` was broken by recent SDK updates. I removed the outdated calls. Previously several functions let users pull sessions using lims, nwb, or confusingly, through the lims API. I removed that last option since it no longer exists. I did not check for other instances of these outdated classes, or other outdated classes in this module.