### PR TITLE
return failed experiments when not filtering for release_data_only

### DIFF
--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -220,7 +220,7 @@ def get_platform_paper_experiment_table(add_extra_columns=True):
 
 
 def get_filtered_ophys_experiment_table(include_failed_data=False, release_data_only=True, exclude_ai94=True,
-                                        add_extra_columns=True, from_cached_file=False, overwrite_cached_file=False):
+                                        add_extra_columns=False, from_cached_file=False, overwrite_cached_file=False):
     """
     Loads a list of available ophys experiments FROM LIMS (not S3 cache) and adds additional useful columns to the table.
     By default, loads from a saved cached file.
@@ -266,7 +266,7 @@ def get_filtered_ophys_experiment_table(include_failed_data=False, release_data_
             print('getting up-to-date experiment_table from lims')
             # get everything in lims
             cache = bpc.from_lims()
-            experiments = cache.get_ophys_experiment_table()
+            experiments = cache.get_ophys_experiment_table(passed_only=False)
             # limit to the 4 VisualBehavior project codes
             experiments = filtering.limit_to_production_project_codes(experiments)
             if add_extra_columns:


### PR DESCRIPTION
This PR adds `passed_only`=False to the SDK call to get the experiments table in `get_filtered_ophys_experiment_table()` to make sure that failed experiments are also returned when `release_data_only`=False and `include_failed_data`=True. 

This `passed_only` flag was recently added to the SDK with the default being True, which has caused much confusion (see https://github.com/AllenInstitute/AllenSDK/issues/2243). I have requested that instead they make a published_only flag and set it to False by default so that users can do their own filtering, which is typically what you want to do when loading from lims. Otherwise we can just use the S3 cache to get published data. 

The PR also sets `add_extra_columns` to False by default because it is slow and most of the extra columns that we had been adding in the past are now part of the SDK experiments table itself. The remaining extra columns are primarily for detailed QC evaluations and dont need to be there by default. 