### PR TITLE
update extended stim and trials to generate and cache behavior metrics

### DIFF
--- a/scripts/cache_behavior_performance_for_all_sessions.py
+++ b/scripts/cache_behavior_performance_for_all_sessions.py
@@ -29,6 +29,7 @@ def deploy_get_behavior_summary_for_all_sessions():
     # import visual_behavior.data_access.utilities as utilities
     # behavior_session_ids = utilities.get_behavior_session_ids_to_analyze()
 
+    import pandas as pd
     import visual_behavior.data_access.loading as loading
     df = pd.read_csv(os.path.join(loading.get_platform_analysis_cache_dir(), 'behavior_only_sessions_without_nwbs.csv'))
     behavior_session_ids = df.behavior_session_id.values

--- a/scripts/cache_behavior_performance_for_all_sessions.py
+++ b/scripts/cache_behavior_performance_for_all_sessions.py
@@ -1,44 +1,41 @@
 import os
-import allensdk.brain_observatory.behavior.behavior_project_cache as bpc
+# import allensdk.brain_observatory.behavior.behavior_project_cache as bpc
 from slurm_deploy import Slurm
+import argparse
 import pathlib
 import time
 
 
 def deploy_get_behavior_summary_for_all_sessions():
-    # data_folder = '/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache'
-    # cache = bpc.VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir=data_folder)
-    # behavior_session_table = cache.get_behavior_session_table()
-    # behavior_session_ids = behavior_session_table.index.values
-
-    import visual_behavior.data_access.utilities as utilities
-    behavior_session_ids = utilities.get_behavior_session_ids_to_analyze()
-
-
-    slurm = Slurm(
-        python_script=None, 
-        job_name=None, 
-        partition='braintv', 
-        cpus_per_task=1, 
-        memory='20gb',
-        time='01:00:00',
-        username=None,
-    )
 
     current_location = pathlib.Path(__file__).parent.resolve()
     python_script_to_run = os.path.join(current_location, 'cache_behavior_performance_for_one_session.py')
+
+    # define the job record output folder
+    stdout_location = r"/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/cluster_jobs/behavior_metrics"
+
+
+    slurm = Slurm(
+        job_name='cache_performance',
+        partition='braintv', 
+        cpus_per_task=1, 
+        mem='20g',
+        time='01:00:00',
+        output=f'{stdout_location}/{Slurm.JOB_ARRAY_MASTER_ID}_{Slurm.JOB_ARRAY_ID}.out',
+    )
+
+    import visual_behavior.data_access.utilities as utilities
+    behavior_session_ids = utilities.get_behavior_session_ids_to_analyze()
 
     methods = ['stimulus_based', 'trial_based', 'sdk']
 
     for method in methods:
         for behavior_session_id in behavior_session_ids:
             print('deploying job for bsid {}'.format(behavior_session_id))
-            slurm.python_script = '{} --behavior-session-id {} --method {}'.format(python_script_to_run, behavior_session_id, method)
-            slurm.job_name = 'bsid_{}'.format(behavior_session_id)
+            args_to_pass = '--behavior-session-id {} --method {}'.format(behavior_session_id, method)
+            job_title = 'behavior_session_id_{}'.format(behavior_session_id)
 
-            slurm.deploy_job()
-
-            time.sleep(0.05)
+            slurm.sbatch(python_executable + ' ' + python_script_to_run + ' ' + args_to_pass)
 
 
 if __name__ == "__main__":

--- a/scripts/cache_behavior_performance_for_all_sessions.py
+++ b/scripts/cache_behavior_performance_for_all_sessions.py
@@ -6,34 +6,39 @@ import time
 
 
 def deploy_get_behavior_summary_for_all_sessions():
-    data_folder = '/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache'
-    cache = bpc.VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir=data_folder)
+    # data_folder = '/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache'
+    # cache = bpc.VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir=data_folder)
+    # behavior_session_table = cache.get_behavior_session_table()
+    # behavior_session_ids = behavior_session_table.index.values
 
-    behavior_session_table = cache.get_behavior_session_table()
+    import visual_behavior.data_access.utilities as utilities
+    behavior_session_ids = utilities.get_behavior_session_ids_to_analyze()
+
 
     slurm = Slurm(
         python_script=None, 
         job_name=None, 
         partition='braintv', 
         cpus_per_task=1, 
-        memory='16gb', 
-        time='00:3:00',
+        memory='20gb',
+        time='01:00:00',
         username=None,
     )
 
     current_location = pathlib.Path(__file__).parent.resolve()
     python_script_to_run = os.path.join(current_location, 'cache_behavior_performance_for_one_session.py')
 
-    method = 'stimulus_based'
+    methods = ['stimulus_based', 'trial_based', 'sdk']
 
-    for behavior_session_id, row in behavior_session_table.iterrows():
-        print('deploying job for bsid {}'.format(behavior_session_id))
-        slurm.python_script = '{} --behavior-session-id {} --method {}'.format(python_script_to_run, behavior_session_id, method)
-        slurm.job_name = 'bsid_{}'.format(behavior_session_id)
+    for method in methods:
+        for behavior_session_id in behavior_session_ids:
+            print('deploying job for bsid {}'.format(behavior_session_id))
+            slurm.python_script = '{} --behavior-session-id {} --method {}'.format(python_script_to_run, behavior_session_id, method)
+            slurm.job_name = 'bsid_{}'.format(behavior_session_id)
 
-        slurm.deploy_job()
+            slurm.deploy_job()
 
-        time.sleep(0.05)
+            time.sleep(0.05)
 
 
 if __name__ == "__main__":

--- a/scripts/cache_behavior_performance_for_all_sessions.py
+++ b/scripts/cache_behavior_performance_for_all_sessions.py
@@ -11,6 +11,8 @@ def deploy_get_behavior_summary_for_all_sessions():
     current_location = pathlib.Path(__file__).parent.resolve()
     python_script_to_run = os.path.join(current_location, 'cache_behavior_performance_for_one_session.py')
 
+    python_executable = "{}/anaconda2/envs/{}/bin/python".format(os.path.expanduser('~'), 'visual_behavior_sdk')
+
     # define the job record output folder
     stdout_location = r"/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/cluster_jobs/behavior_metrics"
 

--- a/scripts/cache_behavior_performance_for_all_sessions.py
+++ b/scripts/cache_behavior_performance_for_all_sessions.py
@@ -26,18 +26,22 @@ def deploy_get_behavior_summary_for_all_sessions():
         output=f'{stdout_location}/{Slurm.JOB_ARRAY_MASTER_ID}_{Slurm.JOB_ARRAY_ID}.out',
     )
 
-    import visual_behavior.data_access.utilities as utilities
-    behavior_session_ids = utilities.get_behavior_session_ids_to_analyze()
+    # import visual_behavior.data_access.utilities as utilities
+    # behavior_session_ids = utilities.get_behavior_session_ids_to_analyze()
 
-    methods = ['stimulus_based', 'trial_based', 'sdk']
+    import visual_behavior.data_access.loading as loading
+    df = pd.read_csv(os.path.join(loading.get_platform_analysis_cache_dir(), 'behavior_only_sessions_without_nwbs.csv'))
+    behavior_session_ids = df.behavior_session_id.values
 
-    for method in methods:
-        for behavior_session_id in behavior_session_ids:
-            print('deploying job for bsid {}'.format(behavior_session_id))
-            args_to_pass = '--behavior-session-id {} --method {}'.format(behavior_session_id, method)
-            job_title = 'behavior_session_id_{}'.format(behavior_session_id)
+    # methods = ['stimulus_based', 'trial_based', 'sdk']
+    method = 'sdk'
+    # for method in methods:
+    for behavior_session_id in behavior_session_ids:
+        print('deploying job for bsid {}'.format(behavior_session_id))
+        args_to_pass = '--behavior-session-id {} --method {}'.format(behavior_session_id, method)
+        job_title = 'behavior_session_id_{}'.format(behavior_session_id)
 
-            slurm.sbatch(python_executable + ' ' + python_script_to_run + ' ' + args_to_pass)
+        slurm.sbatch(python_executable + ' ' + python_script_to_run + ' ' + args_to_pass)
 
 
 if __name__ == "__main__":

--- a/scripts/cache_behavior_performance_for_all_sessions.py
+++ b/scripts/cache_behavior_performance_for_all_sessions.py
@@ -1,6 +1,6 @@
 import os
 # import allensdk.brain_observatory.behavior.behavior_project_cache as bpc
-from slurm_deploy import Slurm
+from simple_slurm import Slurm
 import argparse
 import pathlib
 import time

--- a/scripts/cache_behavior_performance_for_all_sessions.py
+++ b/scripts/cache_behavior_performance_for_all_sessions.py
@@ -21,8 +21,8 @@ def deploy_get_behavior_summary_for_all_sessions():
         job_name='cache_performance',
         partition='braintv', 
         cpus_per_task=1, 
-        mem='20g',
-        time='01:00:00',
+        mem='40g',
+        time='10:00:00',
         output=f'{stdout_location}/{Slurm.JOB_ARRAY_MASTER_ID}_{Slurm.JOB_ARRAY_ID}.out',
     )
 
@@ -30,19 +30,22 @@ def deploy_get_behavior_summary_for_all_sessions():
     # behavior_session_ids = utilities.get_behavior_session_ids_to_analyze()
 
     import pandas as pd
-    import visual_behavior.data_access.loading as loading
-    df = pd.read_csv(os.path.join(loading.get_platform_analysis_cache_dir(), 'behavior_only_sessions_without_nwbs.csv'))
+    # import visual_behavior.data_access.loading as loading
+    # df = pd.read_csv(os.path.join(loading.get_platform_analysis_cache_dir(), 'behavior_only_sessions_without_nwbs.csv'))
+    filepath = r"//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache/behavior_only_sessions_without_nwbs.csv"
+    df = pd.read_csv(filepath)
     behavior_session_ids = df.behavior_session_id.values
 
     # methods = ['stimulus_based', 'trial_based', 'sdk']
     method = 'sdk'
     # for method in methods:
-    for behavior_session_id in behavior_session_ids:
-        print('deploying job for bsid {}'.format(behavior_session_id))
-        args_to_pass = '--behavior-session-id {} --method {}'.format(behavior_session_id, method)
-        job_title = 'behavior_session_id_{}'.format(behavior_session_id)
+    # for behavior_session_id in behavior_session_ids:
+    behavior_session_id = behavior_session_ids[0]
+    print('deploying job for bsid {}'.format(behavior_session_id))
+    args_to_pass = '--behavior-session-id {} --method {}'.format(behavior_session_id, method)
+    job_title = 'behavior_session_id_{}'.format(behavior_session_id)
 
-        slurm.sbatch(python_executable + ' ' + python_script_to_run + ' ' + args_to_pass)
+    slurm.sbatch(python_executable + ' ' + python_script_to_run + ' ' + args_to_pass)
 
 
 if __name__ == "__main__":

--- a/scripts/cache_behavior_performance_for_one_session.py
+++ b/scripts/cache_behavior_performance_for_one_session.py
@@ -8,8 +8,9 @@ if __name__ == "__main__":
     # define args
     parser = argparse.ArgumentParser()
     parser.add_argument('--behavior-session-id', type=int)
-    parser.add_argument('--method', type=str, default='stimulus_based')
+    parser.add_argument('--method', type=str)
 
     args = parser.parse_args()
 
+    print(args.behavior_session_id, args.method)
     cache_behavior_performance(args.behavior_session_id, args.method)

--- a/scripts/cache_behavior_performance_for_one_session.py
+++ b/scripts/cache_behavior_performance_for_one_session.py
@@ -11,8 +11,24 @@ if __name__ == "__main__":
     parser.add_argument('--method', type=str)
 
     args = parser.parse_args()
-    behavior_session_id = args.behavior_session_id
-    method = args.method
-    print(behavior_session_id, method)
-    vbu.cache_behavior_stats(behavior_session_id=behavior_session_id, method=method)
+    # behavior_session_id = args.behavior_session_id
+    # method = args.method
+    # print(behavior_session_id, method)
+    # vbu.cache_behavior_stats(behavior_session_id=behavior_session_id, method=method)
     # cache_behavior_performance(args.behavior_session_id, args.method)
+
+    # import pandas as pd
+    # import visual_behavior.data_access.loading as loading
+    #
+    # df = pd.read_csv(os.path.join(loading.get_platform_analysis_cache_dir(), 'behavior_only_sessions_without_nwbs.csv'))
+    # behavior_session_ids = df.behavior_session_id.values
+
+    # behavior only data
+    import visual_behavior.data_access.loading as loading
+    behavior_sessions = loading.get_platform_paper_behavior_session_table()
+    # remove all ophys sessions
+    behavior_sessions = behavior_sessions[behavior_sessions.session_type.str.contains('OPHYS') == False]
+    behavior_session_ids = behavior_sessions.index.values
+
+    for behavior_session_id in behavior_session_ids:
+        vbu.cache_behavior_stats(behavior_session_id, 'sdk')

--- a/scripts/cache_behavior_performance_for_one_session.py
+++ b/scripts/cache_behavior_performance_for_one_session.py
@@ -31,4 +31,7 @@ if __name__ == "__main__":
     behavior_session_ids = behavior_sessions.index.values
 
     for behavior_session_id in behavior_session_ids:
-        vbu.cache_behavior_stats(behavior_session_id, 'sdk')
+        try:
+            vbu.cache_behavior_stats(behavior_session_id, 'sdk')
+        except:
+            print('problem for behavior_session_id:', behavior_session_id)

--- a/scripts/cache_behavior_performance_for_one_session.py
+++ b/scripts/cache_behavior_performance_for_one_session.py
@@ -1,8 +1,8 @@
 import visual_behavior.utilities as vbu
 import argparse
 
-def cache_behavior_performance(behavior_session_id, method):
-    vbu.cache_behavior_stats(behavior_session_id, method)
+# def cache_behavior_performance(behavior_session_id, method):
+#     vbu.cache_behavior_stats(behavior_session_id, method)
 
 if __name__ == "__main__":
     # define args
@@ -13,4 +13,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     print(args.behavior_session_id, args.method)
-    cache_behavior_performance(args.behavior_session_id, args.method)
+    vbu.cache_behavior_stats(behavior_session_id=behavior_session_id, method=method)
+    # cache_behavior_performance(args.behavior_session_id, args.method)

--- a/scripts/cache_behavior_performance_for_one_session.py
+++ b/scripts/cache_behavior_performance_for_one_session.py
@@ -11,7 +11,8 @@ if __name__ == "__main__":
     parser.add_argument('--method', type=str)
 
     args = parser.parse_args()
-
-    print(args.behavior_session_id, args.method)
+    behavior_session_id = args.behavior_session_id
+    method = args.method
+    print(behavior_session_id, method)
     vbu.cache_behavior_stats(behavior_session_id=behavior_session_id, method=method)
     # cache_behavior_performance(args.behavior_session_id, args.method)

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -615,8 +615,7 @@ class BehaviorOphysDataset(BehaviorOphysExperiment):
         trials = super().trials.copy()
         trials = reformat.add_epoch_times(trials)
         trials = reformat.add_trial_type_to_trials_table(trials)
-        trials = reformat.add_reward_rate_to_trials_table(trials)
-        trials = reformat.add_engagement_state_to_trials_table(trials, self.extended_stimulus_presentations)
+        trials = reformat.add_reward_rate_and_engagement_state_to_trials_table(trials, self.extended_stimulus_presentations)
         self._extended_trials = trials
         return self._extended_trials
 
@@ -790,8 +789,7 @@ class BehaviorDataset(BehaviorSession):
         trials = super().trials.copy()
         trials = reformat.add_epoch_times(trials)
         trials = reformat.add_trial_type_to_trials_table(trials)
-        trials = reformat.add_reward_rate_to_trials_table(trials)
-        trials = reformat.add_engagement_state_to_trials_table(trials, self.extended_stimulus_presentations)
+        trials = reformat.add_reward_rate_and_engagement_state_to_trials_table(trials, self.extended_stimulus_presentations)
         self._extended_trials = trials
         return self._extended_trials
 
@@ -799,8 +797,7 @@ class BehaviorDataset(BehaviorSession):
 def get_extended_trials_table(trials, extended_stimulus_presentations):
     extended_trials = reformat.add_epoch_times(trials)
     extended_trials = reformat.add_trial_type_to_trials_table(extended_trials)
-    extended_trials = reformat.add_reward_rate_to_trials_table(extended_trials)
-    extended_trials = reformat.add_engagement_state_to_trials_table(extended_trials, extended_stimulus_presentations)
+    extended_trials = reformat.add_reward_rate_and_engagement_state_to_trials_table(extended_trials, extended_stimulus_presentations)
     return extended_trials
 
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -10,7 +10,6 @@ from visual_behavior.data_access import from_lims
 import visual_behavior.database as db
 
 import os
-import sys
 import glob
 import h5py  # for loading motion corrected movie
 import numpy as np
@@ -606,8 +605,8 @@ class BehaviorOphysDataset(BehaviorOphysExperiment):
 
     @property
     def extended_stimulus_presentations(self):
-        extended_stimulus_presentations = get_extened_stimulus_presentations(self.stimulus_presentations.copy(),
-                                                                             self.licks, self.rewards, self.running_speed, self.eye_tracking)
+        extended_stimulus_presentations = get_extended_stimulus_presentations(self.stimulus_presentations.copy(),
+                                                                              self.licks, self.rewards, self.running_speed, self.eye_tracking)
         self._extended_stimulus_presentations = extended_stimulus_presentations
         return self._extended_stimulus_presentations
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -69,7 +69,7 @@ def get_platform_analysis_cache_dir():
     This is the cache directory to use for all platform paper analysis
     This cache contains NWB files downloaded directly from AWS
     """
-    return r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache'
+    return r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache/2.12.4'
 
 
 def get_production_cache_dir():

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -805,7 +805,8 @@ def get_extended_trials_table(trials, extended_stimulus_presentations):
     return extended_trials
 
 
-def get_behavior_dataset(behavior_session_id, from_lims=False, from_nwb=True, get_extended_stimulus_presentations=False, get_extended_trials=True):
+def get_behavior_dataset(behavior_session_id, from_lims=False, from_nwb=True,
+                         get_extended_stimulus_presentations=False, get_extended_trials=True):
     """
     Gets behavior data for one session, either using the SDK LIMS API, SDK NWB API, or using BehaviorDataset wrapper which inherits the LIMS API BehaviorSession object, and adds access to extended stimulus_presentations and trials.
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -605,7 +605,7 @@ class BehaviorOphysDataset(BehaviorOphysExperiment):
 
     @property
     def extended_stimulus_presentations(self):
-        extended_stimulus_presentations = get_extended_stimulus_presentations(self.stimulus_presentations.copy(),
+        extended_stimulus_presentations = get_extended_stimulus_presentations_table(self.stimulus_presentations.copy(),
                                                                               self.licks, self.rewards, self.running_speed, self.eye_tracking)
         self._extended_stimulus_presentations = extended_stimulus_presentations
         return self._extended_stimulus_presentations

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -483,7 +483,7 @@ def get_extended_stimulus_presentations_table(stimulus_presentations, licks, rew
     stimulus_presentations['reward_rate'] = stimulus_presentations['rewarded'].rolling(window=320, min_periods=1,
                                                                                        win_type='triang').mean() * (60 / .75)  # units of rewards/min
 
-    reward_threshold = 2  # threshold of 2 rewards per minute; if using rewards per second, use 1/90
+    reward_threshold = 2/3  # 2/3 rewards per minute = 1/90 rewards/second
     stimulus_presentations['engaged'] = [x > reward_threshold for x in stimulus_presentations['reward_rate']]
     stimulus_presentations['engagement_state'] = ['engaged' if True else 'disengaged' for engaged in stimulus_presentations['engaged'].values]
     stimulus_presentations = reformat.add_response_latency(stimulus_presentations)

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -615,7 +615,8 @@ class BehaviorOphysDataset(BehaviorOphysExperiment):
         trials = super().trials.copy()
         trials = reformat.add_epoch_times(trials)
         trials = reformat.add_trial_type_to_trials_table(trials)
-        trials = reformat.add_reward_rate_and_engagement_state_to_trials_table(trials, self.extended_stimulus_presentations)
+        trials = reformat.add_reward_rate_to_trials_table(trials, self.extended_stimulus_presentations)
+        trials = reformat.add_engagement_state_to_trials_table(trials, self.extended_stimulus_presentations)
         self._extended_trials = trials
         return self._extended_trials
 
@@ -789,7 +790,8 @@ class BehaviorDataset(BehaviorSession):
         trials = super().trials.copy()
         trials = reformat.add_epoch_times(trials)
         trials = reformat.add_trial_type_to_trials_table(trials)
-        trials = reformat.add_reward_rate_and_engagement_state_to_trials_table(trials, self.extended_stimulus_presentations)
+        trials = reformat.add_reward_rate_to_trials_table(trials, self.extended_stimulus_presentations)
+        trials = reformat.add_engagement_state_to_trials_table(trials, self.extended_stimulus_presentations)
         self._extended_trials = trials
         return self._extended_trials
 
@@ -797,7 +799,8 @@ class BehaviorDataset(BehaviorSession):
 def get_extended_trials_table(trials, extended_stimulus_presentations):
     extended_trials = reformat.add_epoch_times(trials)
     extended_trials = reformat.add_trial_type_to_trials_table(extended_trials)
-    extended_trials = reformat.add_reward_rate_and_engagement_state_to_trials_table(extended_trials, extended_stimulus_presentations)
+    extended_trials = reformat.add_reward_rate_to_trials_table(extended_trials, extended_stimulus_presentations)
+    extended_trials = reformat.add_engagement_state_to_trials_table(extended_trials, extended_stimulus_presentations)
     return extended_trials
 
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -797,7 +797,15 @@ class BehaviorDataset(BehaviorSession):
         return self._extended_trials
 
 
-def get_behavior_dataset(behavior_session_id, from_lims=False, from_nwb=False):
+def get_extended_trials_table(trials, extended_stimulus_presentations):
+    extended_trials = reformat.add_epoch_times(trials)
+    extended_trials = reformat.add_trial_type_to_trials_table(extended_trials)
+    extended_trials = reformat.add_reward_rate_to_trials_table(extended_trials)
+    extended_trials = reformat.add_engagement_state_to_trials_table(extended_trials, extended_stimulus_presentations)
+    return extended_trials
+
+
+def get_behavior_dataset(behavior_session_id, from_lims=False, from_nwb=True, get_extended_stimulus_presentations=False, get_extended_trials=True):
     """
     Gets behavior data for one session, either using the SDK LIMS API, SDK NWB API, or using BehaviorDataset wrapper which inherits the LIMS API BehaviorSession object, and adds access to extended stimulus_presentations and trials.
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -483,7 +483,7 @@ def get_extended_stimulus_presentations_table(stimulus_presentations, licks, rew
     stimulus_presentations['reward_rate'] = stimulus_presentations['rewarded'].rolling(window=320, min_periods=1,
                                                                                        win_type='triang').mean() * (60 / .75)  # units of rewards/min
 
-    reward_threshold = 2/3  # 2/3 rewards per minute = 1/90 rewards/second
+    reward_threshold = 2 / 3  # 2/3 rewards per minute = 1/90 rewards/second
     stimulus_presentations['engaged'] = [x > reward_threshold for x in stimulus_presentations['reward_rate']]
     stimulus_presentations['engagement_state'] = ['engaged' if True else 'disengaged' for engaged in stimulus_presentations['engaged'].values]
     stimulus_presentations = reformat.add_response_latency(stimulus_presentations)
@@ -606,7 +606,7 @@ class BehaviorOphysDataset(BehaviorOphysExperiment):
     @property
     def extended_stimulus_presentations(self):
         extended_stimulus_presentations = get_extended_stimulus_presentations_table(self.stimulus_presentations.copy(),
-                                                                              self.licks, self.rewards, self.running_speed, self.eye_tracking)
+                                                                                    self.licks, self.rewards, self.running_speed, self.eye_tracking)
         self._extended_stimulus_presentations = extended_stimulus_presentations
         return self._extended_stimulus_presentations
 

--- a/visual_behavior/data_access/reformat.py
+++ b/visual_behavior/data_access/reformat.py
@@ -53,7 +53,7 @@ def add_session_type_exposure_number_to_experiments_table(experiments):
     return experiments
 
 
-def add_engagement_state_to_trials_table(trials, extended_stimulus_presentations):
+def add_reward_rate_and_engagement_state_to_trials_table(trials, extended_stimulus_presentations):
     '''
     adds `engaged` and `engagement_state` fields to the trial table
     both are pulled from the value of the stimulus table that is closest to the time at the start of each trial
@@ -70,6 +70,7 @@ def add_engagement_state_to_trials_table(trials, extended_stimulus_presentations
 
     # define the columns from extended_stimulus_presentations that we want to merge into trials
     cols_to_merge = [
+        'reward_rate',
         'engaged',
         'engagement_state'
     ]

--- a/visual_behavior/data_access/reformat.py
+++ b/visual_behavior/data_access/reformat.py
@@ -258,7 +258,7 @@ def add_trial_type_to_trials_table(trials):
 
 def add_reward_rate_to_trials_table(trials):
     trials['rewarded'] = [1 if np.isnan(reward_time) == False else 0 for reward_time in trials.reward_time.values]
-    trials['reward_rate'] = trials['rewarded'].rolling(window=100, min_periods=1, win_type='triang').mean()
+    trials['reward_rate'] = trials['rewarded'].rolling(window=100, min_periods=1, win_type='triang').mean() * (60 / .75)  # units of rewards/min
     return trials
 
 

--- a/visual_behavior/data_access/reformat.py
+++ b/visual_behavior/data_access/reformat.py
@@ -100,7 +100,6 @@ def add_engagement_state_to_trials_table(trials, extended_stimulus_presentations
 
     # define the columns from extended_stimulus_presentations that we want to merge into trials
     cols_to_merge = [
-        'reward_rate',
         'engaged',
         'engagement_state'
     ]

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -1754,3 +1754,42 @@ def count_mice_expts_containers_cells(df):
     counts = counts.merge(containers, on=['cell_type', 'experience_level'])
     counts = counts.merge(cells, on=['cell_type', 'experience_level'])
     return counts
+
+
+def count_mice_expts_containers(df):
+    """
+    count the number of mice, experiments, containers in input dataframe
+    input dataframe is typically experiments_table
+    """
+    mice = value_counts(df, conditions=['cell_type', 'experience_level', 'mouse_id'])
+    experiments = value_counts(df, conditions=['cell_type', 'experience_level', 'ophys_experiment_id'])
+    containers = value_counts(df, conditions=['cell_type', 'experience_level', 'ophys_container_id'])
+
+    counts = mice.merge(experiments, on=['cell_type', 'experience_level'])
+    counts = counts.merge(containers, on=['cell_type', 'experience_level'])
+    return counts
+
+
+def get_behavior_session_ids_to_analyze():
+    """
+    Gets a list of behavior_session_ids by combining the behavior_session_ids present in the platform paper experiments table
+    with the behavior_session_ids for non-ophys sessions from the behavior session table,
+    only for mice present in the platform paper experiments table
+    """
+    # ophys data
+    experiments_table = loading.get_platform_paper_experiment_table()
+    # skip passive sessions
+    experiments_table = experiments_table[experiments_table.passive==False]
+    ophys_behavior_session_ids = list(experiments_table.behavior_session_id.unique())
+
+    # behavior only data
+    behavior_sessions = loading.get_platform_paper_behavior_session_table()
+    # limit to mice with ophys data going in to the paper
+    behavior_sessions = behavior_sessions[behavior_sessions.mouse_id.isin(experiments_table.mouse_id.unique())]
+    # remove all ophys sessions, use experiments_table to get ophys info
+    behavior_sessions = behavior_sessions[behavior_sessions.session_type.str.contains('OPHYS') == False]
+    behavior_session_session_ids = list(behavior_sessions.index.values)
+
+    behavior_session_ids_to_analyze = ophys_behavior_session_ids + behavior_session_session_ids
+
+    return behavior_session_ids_to_analyze

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -1779,7 +1779,7 @@ def get_behavior_session_ids_to_analyze():
     # ophys data
     experiments_table = loading.get_platform_paper_experiment_table()
     # skip passive sessions
-    experiments_table = experiments_table[experiments_table.passive==False]
+    experiments_table = experiments_table[experiments_table.passive == False]
     ophys_behavior_session_ids = list(experiments_table.behavior_session_id.unique())
 
     # behavior only data

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -1774,7 +1774,7 @@ def get_behavior_session_ids_to_analyze():
     """
     Gets a list of behavior_session_ids by combining the behavior_session_ids present in the platform paper experiments table
     with the behavior_session_ids for non-ophys sessions from the behavior session table,
-    only for mice present in the platform paper experiments table
+    for mice present in the platform paper experiments table
     """
     # ophys data
     experiments_table = loading.get_platform_paper_experiment_table()

--- a/visual_behavior/utilities.py
+++ b/visual_behavior/utilities.py
@@ -1090,7 +1090,7 @@ def get_behavior_stats(behavior_session_id, method='stimulus_based', engaged_onl
     '''
     output_dict = {'behavior_session_id': behavior_session_id}
     print('getting metrics for behavior_session_id:', behavior_session_id)
-    session = loading.get_behavior_dataset(behavior_session_id, from_nwb=True, get_extended_trials=True)
+    session = loading.get_behavior_dataset(behavior_session_id, from_nwb=True, get_extended_trials=False)
     try:
         if method == 'trial_based':
 

--- a/visual_behavior/utilities.py
+++ b/visual_behavior/utilities.py
@@ -1190,16 +1190,13 @@ def cache_behavior_stats(behavior_session_id, engaged_only=True, method='stimulu
 
     cache_dir = get_behavior_stats_cache_dir(method)
 
-    behavior_stats_df = pd.DataFrame(
-        get_behavior_stats(behavior_session_id, engaged_only),
-        index=[0]
-    )
+    behavior_stats_df = pd.DataFrame(get_behavior_stats(behavior_session_id, engaged_only), index=[0])
 
     filename = 'behavior_summary_behavior_session_id={}.h5'.format(behavior_session_id)
-    behavior_stats_df.to_hdf(
-        os.path.join(cache_dir, filename),
-        key='data'
-    )
+    filepath = os.path.join(cache_dir, filename)
+    if os.path.exists(filepath):
+        os.remove(filepath)
+    behavior_stats_df.to_hdf(filepath, key='data')
 
 
 def get_cached_behavior_stats(behavior_session_id, engaged_only=True, method='stimulus_based'):

--- a/visual_behavior/utilities.py
+++ b/visual_behavior/utilities.py
@@ -1047,7 +1047,7 @@ def annotate_stimuli(dataset, inplace=False):
         return stimulus_presentations
 
 
-def get_behavior_stats(behavior_session_id, engaged_only=True, method='stimulus_based'):
+def get_behavior_stats(behavior_session_id, method='stimulus_based', engaged_only=True):
     '''
     gets behavior stats for a given behavior session
     relies on the existence of a behavioral model for a given session
@@ -1089,9 +1089,9 @@ def get_behavior_stats(behavior_session_id, engaged_only=True, method='stimulus_
 
     '''
     output_dict = {'behavior_session_id': behavior_session_id}
+    print('getting metrics for behavior_session_id:', behavior_session_id)
+    session = loading.get_behavior_dataset(behavior_session_id, from_nwb=True, get_extended_trials=True)
     try:
-        print('getting metrics for behavior_session_id:', behavior_session_id)
-        session = loading.get_behavior_dataset(behavior_session_id, from_nwb=True, get_extended_trials=True)
         if method == 'trial_based':
 
             trials = session.extended_trials
@@ -1190,8 +1190,8 @@ def cache_behavior_stats(behavior_session_id, method='stimulus_based', engaged_o
     '''
 
     cache_dir = get_behavior_stats_cache_dir(method)
-
-    behavior_stats_df = pd.DataFrame(get_behavior_stats(behavior_session_id, engaged_only), index=[0])
+    behavior_stats = get_behavior_stats(behavior_session_id, method=method, engaged_only=engaged_only)
+    behavior_stats_df = pd.DataFrame(behavior_stats, index=[0])
 
     filename = 'behavior_summary_behavior_session_id={}.h5'.format(behavior_session_id)
     filepath = os.path.join(cache_dir, filename)

--- a/visual_behavior/utilities.py
+++ b/visual_behavior/utilities.py
@@ -1090,6 +1090,7 @@ def get_behavior_stats(behavior_session_id, engaged_only=True, method='stimulus_
     '''
     output_dict = {'behavior_session_id': behavior_session_id}
     try:
+        print('getting status for behavior_session_id:', behavior_session_id)
         session = loading.get_behavior_dataset(behavior_session_id, from_nwb=True, get_extended_trials=True)
         if method == 'trial_based':
 

--- a/visual_behavior/utilities.py
+++ b/visual_behavior/utilities.py
@@ -1090,7 +1090,7 @@ def get_behavior_stats(behavior_session_id, engaged_only=True, method='stimulus_
     '''
     output_dict = {'behavior_session_id': behavior_session_id}
     try:
-        session = loading.get_behavior_dataset(behavior_session_id, get_extended_trials=True, get_extended_stimulus_presentations=True)
+        session = loading.get_behavior_dataset(behavior_session_id, from_nwb=True, get_extended_trials=True)
         if method == 'trial_based':
 
             trials = session.extended_trials

--- a/visual_behavior/utilities.py
+++ b/visual_behavior/utilities.py
@@ -1159,11 +1159,11 @@ def get_behavior_stats_cache_dir(method='stimulus_based'):
     :return:
     """
     if method == 'trial_based':
-        cache_dir = r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache/behavior_performance/behavior_perfomance_summary_trial_based'
+        cache_dir = r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache/behavior_performance/behavior_performance_summary_trial_based'
     elif method == 'stimulus_based':
-        cache_dir = r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache/behavior_performance/behavior_perfomance_summary_stimulus_based'
+        cache_dir = r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache/behavior_performance/behavior_performance_summary_stimulus_based'
     elif method == 'sdk':
-        cache_dir = r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache/behavior_performance/behavior_perfomance_metrics_sdk'
+        cache_dir = r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache/behavior_performance/behavior_performance_metrics_sdk'
     return cache_dir
 
 

--- a/visual_behavior/utilities.py
+++ b/visual_behavior/utilities.py
@@ -1191,7 +1191,7 @@ def cache_behavior_stats(behavior_session_id, method='stimulus_based', engaged_o
 
     cache_dir = get_behavior_stats_cache_dir(method)
     behavior_stats = get_behavior_stats(behavior_session_id, method=method, engaged_only=engaged_only)
-    behavior_stats_df = pd.DataFrame(behavior_stats, index=[0])
+    behavior_stats_df = pd.DataFrame(behavior_stats, index=behavior_session_id)
 
     filename = 'behavior_summary_behavior_session_id={}.h5'.format(behavior_session_id)
     filepath = os.path.join(cache_dir, filename)

--- a/visual_behavior/utilities.py
+++ b/visual_behavior/utilities.py
@@ -1090,7 +1090,7 @@ def get_behavior_stats(behavior_session_id, engaged_only=True, method='stimulus_
     '''
     output_dict = {'behavior_session_id': behavior_session_id}
     try:
-        print('getting status for behavior_session_id:', behavior_session_id)
+        print('getting metrics for behavior_session_id:', behavior_session_id)
         session = loading.get_behavior_dataset(behavior_session_id, from_nwb=True, get_extended_trials=True)
         if method == 'trial_based':
 
@@ -1167,7 +1167,7 @@ def get_behavior_stats_cache_dir(method='stimulus_based'):
     return cache_dir
 
 
-def cache_behavior_stats(behavior_session_id, engaged_only=True, method='stimulus_based'):
+def cache_behavior_stats(behavior_session_id, method='stimulus_based', engaged_only=True):
     '''
     calculates behavior stats for a given session, saves to file
     file format is behavior_summary_behavior_session_id={behavior_session_id}.h5 with key = 'data'
@@ -1198,6 +1198,7 @@ def cache_behavior_stats(behavior_session_id, engaged_only=True, method='stimulu
     if os.path.exists(filepath):
         os.remove(filepath)
     behavior_stats_df.to_hdf(filepath, key='data')
+    print('behavior stats cached for', behavior_session_id, method)
 
 
 def get_cached_behavior_stats(behavior_session_id, engaged_only=True, method='stimulus_based'):


### PR DESCRIPTION
goal was to save performance metrics that Doug computed, but his code didnt run as is, presumably because things have changed since. i made several updates to get the code to run, including computing engagement based on reward rate in get_extended_stimulus_presentations directly, instead of loading from behavior model output files. 

currently testing that it all works on the cluster, there may be a few additional tweaks before it is ready to merge.