### PR TITLE
Fixing circular imports and CircleCI tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ DEV =
     pytest-cov
     pytest-html
     coverage
+    markupsafe==2.0.1
 
 [bumpversion]
 current_version = 0.13.0

--- a/visual_behavior/data_access/reformat.py
+++ b/visual_behavior/data_access/reformat.py
@@ -3,7 +3,6 @@ import glob
 import numpy as np
 import pandas as pd
 
-from visual_behavior.data_access import utilities
 import visual_behavior.ophys.dataset.extended_stimulus_processing as esp
 
 

--- a/visual_behavior/data_access/reformat.py
+++ b/visual_behavior/data_access/reformat.py
@@ -191,18 +191,6 @@ def add_omission_exposure_number_to_experiments_table(experiments, behavior_sess
     return experiments
 
 
-def add_model_outputs_availability_to_table(table):
-    """
-    Evaluates whether model output files are available for each experiment/session in the table
-        Requires that the table has a column 'behavior_session_id' with 9-digit behavior session identifiers
-    :param table: table of experiment or session level metadata (can be experiments_table or ophys_sessions_table)
-    :return: table with added column 'model_outputs_available', values are Boolean
-    """
-    table['model_outputs_available'] = [utilities.model_outputs_available_for_behavior_session(behavior_session_id)
-                                        for behavior_session_id in table.behavior_session_id.values]
-    return table
-
-
 def reformat_experiments_table(experiments):
     """
     adds extra columns to experiments table
@@ -219,7 +207,6 @@ def reformat_experiments_table(experiments):
     # replace session types that are NaN with string None
     experiments.at[experiments[experiments.session_type.isnull()].index.values, 'session_type'] = 'None'
     experiments = add_mouse_seeks_fail_tags_to_experiments_table(experiments)
-    experiments = add_model_outputs_availability_to_table(experiments)
     if 'level_0' in experiments.columns:
         experiments = experiments.drop(columns='level_0')
     if 'index' in experiments.columns:

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 
-#from visual_behavior.data_access import loading
 from visual_behavior.ophys.io.lims_database import LimsDatabase
 from visual_behavior.ophys.sync.sync_dataset import Dataset as SyncDataset
 from visual_behavior.ophys.sync.process_sync import filter_digital, calculate_delay
@@ -51,6 +50,7 @@ def check_for_model_outputs(behavior_session_id):
     :param behavior_session_id:
     :return:
     """
+    raise Exception('See PR #809')
     model_output_dir = loading.get_behavior_model_outputs_dir()
     model_output_file = [file for file in os.listdir(model_output_dir) if
                          (str(behavior_session_id) in file) and ('training' not in file)]
@@ -339,6 +339,7 @@ def model_outputs_available_for_behavior_session(behavior_session_id):
     :param behavior_session_id: 9-digit behavior session ID
     :return: Boolean, True if outputs are available, False if not
     """
+    raise Exception('See PR #809')
     model_output_dir = loading.get_behavior_model_outputs_dir()
     model_output_file = [file for file in os.listdir(model_output_dir) if str(behavior_session_id) in file]
     if len(model_output_file) > 0:
@@ -1776,6 +1777,7 @@ def get_behavior_session_ids_to_analyze():
     with the behavior_session_ids for non-ophys sessions from the behavior session table,
     for mice present in the platform paper experiments table
     """
+    raise Exception('See PR #809')
     # ophys data
     experiments_table = loading.get_platform_paper_experiment_table()
     # skip passive sessions

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -1729,4 +1729,3 @@ def count_mice_expts_containers(df):
     counts = mice.merge(experiments, on=['cell_type', 'experience_level'])
     counts = counts.merge(containers, on=['cell_type', 'experience_level'])
     return counts
-

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 
-from visual_behavior.data_access import loading
+#from visual_behavior.data_access import loading
 from visual_behavior.ophys.io.lims_database import LimsDatabase
 from visual_behavior.ophys.sync.sync_dataset import Dataset as SyncDataset
 from visual_behavior.ophys.sync.process_sync import filter_digital, calculate_delay

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -1730,4 +1730,3 @@ def count_mice_expts_containers(df):
     counts = counts.merge(containers, on=['cell_type', 'experience_level'])
     return counts
 
-

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -1731,27 +1731,3 @@ def count_mice_expts_containers(df):
     return counts
 
 
-def get_behavior_session_ids_to_analyze():
-    """
-    Gets a list of behavior_session_ids by combining the behavior_session_ids present in the platform paper experiments table
-    with the behavior_session_ids for non-ophys sessions from the behavior session table,
-    for mice present in the platform paper experiments table
-    """
-    raise Exception('See PR #809')
-    # ophys data
-    experiments_table = loading.get_platform_paper_experiment_table()
-    # skip passive sessions
-    experiments_table = experiments_table[experiments_table.passive == False]
-    ophys_behavior_session_ids = list(experiments_table.behavior_session_id.unique())
-
-    # behavior only data
-    behavior_sessions = loading.get_platform_paper_behavior_session_table()
-    # limit to mice with ophys data going in to the paper
-    behavior_sessions = behavior_sessions[behavior_sessions.mouse_id.isin(experiments_table.mouse_id.unique())]
-    # remove all ophys sessions, use experiments_table to get ophys info
-    behavior_sessions = behavior_sessions[behavior_sessions.session_type.str.contains('OPHYS') == False]
-    behavior_session_session_ids = list(behavior_sessions.index.values)
-
-    behavior_session_ids_to_analyze = ophys_behavior_session_ids + behavior_session_session_ids
-
-    return behavior_session_ids_to_analyze

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -44,19 +44,6 @@ class LazyLoadable(object):
         self.calculate = calculate
 
 
-def check_for_model_outputs(behavior_session_id):
-    """
-    Checks whether model output file with omission regressors exists (does not say '_training' at end of filename)
-    :param behavior_session_id:
-    :return:
-    """
-    raise Exception('See PR #809')
-    model_output_dir = loading.get_behavior_model_outputs_dir()
-    model_output_file = [file for file in os.listdir(model_output_dir) if
-                         (str(behavior_session_id) in file) and ('training' not in file)]
-    return len(model_output_file) > 0
-
-
 def get_all_session_ids(ophys_experiment_id=None, ophys_session_id=None, behavior_session_id=None, foraging_id=None):
     '''
     a function to get all ID types for a given experiment ID
@@ -330,33 +317,6 @@ def get_donor_id_from_specimen_id(specimen_id, cache=None):
             where specimens.id = '{}'
         '''
         return db.lims_query(lims_query_string.format(specimen_id)).astype(int)
-
-
-def model_outputs_available_for_behavior_session(behavior_session_id):
-    """
-    Check whether behavior model outputs are available in the default directory
-
-    :param behavior_session_id: 9-digit behavior session ID
-    :return: Boolean, True if outputs are available, False if not
-    """
-    raise Exception('See PR #809')
-    model_output_dir = loading.get_behavior_model_outputs_dir()
-    model_output_file = [file for file in os.listdir(model_output_dir) if str(behavior_session_id) in file]
-    if len(model_output_file) > 0:
-        return True
-    else:
-        return False
-
-
-# def get_cell_matching_output_dir_for_container(container_id, experiments_table):
-#     container_expts = experiments_table[experiments_table.container_id==container_id]
-#     ophys_experiment_id = container_expts.index[0]
-#     lims_data = get_lims_data(ophys_experiment_id)
-#     session_dir = lims_data.ophys_session_dir.values[0]
-#     cell_matching_dir = os.path.join(session_dir[:-23], 'experiment_container_'+str(container_id), 'OphysNwayCellMatchingStrategy')
-#     cell_matching_output_dir = os.path.join(cell_matching_dir, np.sort(os.listdir(cell_matching_dir))[-1])
-#     return cell_matching_output_dir
-#
 
 
 def get_cell_matching_output_dir_for_container(experiment_id):


### PR DESCRIPTION
- [x] Pins `markupsafe` version to `2.0.1` in test environment, and thereby resolves #810. 
   - See PR #811 for details
- [x] Removes `data_access.utilties` dependence on `data_access.loading` and thereby resolves #808 

There were three functions in `utilities` that used `loading`. 

- [x] `utilities.check_for_model_outputs()`
   - This is a duplicate!?!? of `loading.check_if_model_output_available` so I am removing this function
- [x] `utilities.model_outputs_available_for_behavior_session()`
   - This is a duplicate!?!? of `loading.check_if_model_output_available` so I am removing this function
   - Called by `reformat.add_model_outputs_availability_to_table()` 
     - [x] so I removed `reformat.add_model_outputs_availability_to_table()`
      - in turn called by `reformat_experiments_table()`. So I removed that function call. 
- [x] `utilities.get_behavior_session_ids_to_analyze()`
   - On slack @matchings says its ok to remove this function, so I am removing it. 
