### PR TITLE
Fix circleci

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ DEV =
     pytest-cov
     pytest-html
     coverage
+    markupsafe==2.0.1
 
 [bumpversion]
 current_version = 0.13.0


### PR DESCRIPTION
- Resolves #810 
- Pinning `markupsafe` version used in testing to `2.0.1` following the advice on https://github.com/aws/aws-sam-cli/issues/3661