### PR TITLE
removing sns.set_context

### DIFF
--- a/visual_behavior/visualization/utils.py
+++ b/visual_behavior/visualization/utils.py
@@ -4,7 +4,6 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-sns.set_context('notebook', font_scale=1.5, rc={'lines.markeredgewidth': 2})
 
 def get_container_plots_dir():
     return r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/qc_plots/container_plots'


### PR DESCRIPTION
PR #804 added a `sns.set_context()` call in `visualization/utils` that caused plots to look unexpectedly different. I'm removing that `set_context()` call. 
- Resolves https://github.com/AllenInstitute/visual_behavior_glm/issues/434