### PR TITLE
Fixes an edge case in extended_stimulus_processing.licks_each_flash

### DIFF
--- a/visual_behavior/ophys/dataset/extended_stimulus_processing.py
+++ b/visual_behavior/ophys/dataset/extended_stimulus_processing.py
@@ -164,7 +164,7 @@ def licks_each_flash(stimulus_presentations_df, licks_df,
     licks_each_flash = stimulus_presentations_df.apply(
         lambda row: lick_times[
             ((
-                lick_times > row["start_time"] + range_relative_to_stimulus_start[0]
+                lick_times >= row["start_time"] + range_relative_to_stimulus_start[0]
             ) & (
                 lick_times < row["start_time"] + range_relative_to_stimulus_start[1]
             ))
@@ -194,7 +194,7 @@ def rewards_each_flash(stimulus_presentations_df, rewards_df,
     rewards_each_flash = stimulus_presentations_df.apply(
         lambda row: reward_times[
             ((
-                reward_times > row["start_time"] + range_relative_to_stimulus_start[0]
+                reward_times >= row["start_time"] + range_relative_to_stimulus_start[0]
             ) & (
                 reward_times < row["start_time"] + range_relative_to_stimulus_start[1]
             ))


### PR DESCRIPTION
`esp.licks_each_flash` and `esp.rewards_each_flash` annotate the rows of `session.stimulus_presentations` with the licks and rewards that happen during each flash. Currently they look for strict inclusion with a set time range relative to the stimulus onset. If the lick or reward happens at exactly the moment the stimulus starts the lick or reward is not assigned to any stimulus. I've fixed that by making the test of for the start of the time range inclusive ">=" rather than ">"