### PR TITLE
get_platform_behavior_sessions was incorrectly filtering out 4x2

### DIFF
--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -272,6 +272,8 @@ def get_platform_paper_behavior_session_table(include_4x2_data=False):
     cache_dir = get_platform_analysis_cache_dir()
     cache = bpc.from_s3_cache(cache_dir=cache_dir)
     behavior_sessions = cache.get_behavior_session_table()
+    # reset index to retain behavior_session_id during the below transformations
+    behavior_sessions = behavior_sessions.reset_index()
 
     # add project codes to behavior sessions
     experiments_table = cache.get_ophys_experiment_table()
@@ -297,6 +299,13 @@ def get_platform_paper_behavior_session_table(include_4x2_data=False):
     behavior_sessions = utilities.add_passive_flag_to_ophys_experiment_table(behavior_sessions)
     behavior_sessions = utilities.add_cell_type_column(behavior_sessions)
     print(len(behavior_sessions), 'sessions after adding session number, passive flag, and cell type columns')
+
+    # add experience_level column
+    behavior_sessions = utilities.add_experience_level_to_behavior_sessions(behavior_sessions)
+    print(len(behavior_sessions), 'sessions after adding experience_level column')
+
+    # reset the index to behavior_session_id
+    behavior_sessions = behavior_sessions.set_index('behavior_session_id')
 
     return behavior_sessions
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -304,6 +304,10 @@ def get_platform_paper_behavior_session_table(include_4x2_data=False):
     behavior_sessions = utilities.add_experience_level_to_behavior_sessions(behavior_sessions)
     print(len(behavior_sessions), 'sessions after adding experience_level column')
 
+    # add training_stage info
+    behavior_sessions = utilities.add_training_stage_info_to_behavior_sessions(behavior_sessions)
+    print(len(behavior_sessions), 'sessions after adding training_stage columns')
+
     # reset the index to behavior_session_id
     behavior_sessions = behavior_sessions.set_index('behavior_session_id')
 

--- a/visual_behavior/data_access/utilities.py
+++ b/visual_behavior/data_access/utilities.py
@@ -1268,6 +1268,26 @@ def correct_dataframe_filepath(dataframe, column_string):
 
 # functions to annotate experiments table with conditions to use for platform paper analysis ######
 
+
+def add_project_code_to_behavior_sessions(behavior_sessions_table, ophys_experiments_table):
+    """
+    Because only ophys sessions have a project_code associated with them, we need to get a table of the project_codes
+    for each mouse_id from the ophys_experiments_table and merge that into the behavior_sessions table so that we can
+    filter the behavior_sessions by project_code
+    """
+    # get project codes for each mouse from experiments table
+    mouse_projects = ophys_experiments_table.drop_duplicates(subset=['mouse_id', 'project_code'])
+    mouse_projects = mouse_projects[['mouse_id', 'project_code']]
+
+    # merge into behavior sessions
+    print(len(behavior_sessions_table), 'behavior sessions in original behavior_sessions table')
+    behavior_sessions = behavior_sessions_table.drop(columns='project_code').merge(mouse_projects, on='mouse_id',
+                                                                                   how='left')
+    print(len(behavior_sessions), 'behavior sessions after merging with project codes')
+
+    return behavior_sessions
+
+
 def add_session_number_to_experiment_table(experiments):
     # add session number column, extracted frrom session_type
     experiments['session_number'] = [int(session_type[6]) if 'OPHYS' in session_type else None for session_type in


### PR DESCRIPTION
because only ophys sessions have a `project_code `in the `behavior_sessions `table, the `VisualBehaviorMultiscope4x2 `behavior training sessions were not being properly filtered out in the `get_platform_paper_behavior_session_table` function. This PR adds a step to merge the `project_codes `from the `ophys_experiment_table `into the `behavior_sessions `table before filtering out the 4x2 sessions. 

As part of this PR, the `get_platform_paper_behavior_session_table `function was also updated to add an `experience_level` column that matches the `ophys_experiments_table `values (Novel 1, Novel >1, Familiar) for ophys sessions, and adds new values for training sessions such that training sessions with gratings have `experience_level`='Gratings', training sessions with images have `experience_level`='Familiar Training' and the first training session with images has `experience_level`='Novel Training'