### PR TITLE
update requires with umap and h5py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ install_requires =
 	dash
 	plotly
 	hdmf<=2.4.0
+	h5py
+	umap
 
 [options.extras_require]
 DEV =


### PR DESCRIPTION
addresses #822

h5py and umap are top level dependencies (but not pytables). Seems like best practices to keep install_requires to this level? Should be sufficient to prevent the import issues you described (FWIW pytables and h5py were install by pip when I did the usual setup.py, on the version before this commit).