### PR TITLE
Fixing path and circular imports

### DIFF
--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -3388,6 +3388,10 @@ def get_multi_session_df_for_conditions(data_type, event_type, conditions, inclu
         experiments_table = get_platform_paper_experiment_table(limit_to_closest_active=True)
         multi_session_df = multi_session_df[multi_session_df.ophys_experiment_id.isin(experiments_table.index.values)]
         print('there are', len(multi_session_df.ophys_experiment_id.unique()), 'experiments in the multi_session_df after limiting to platform experiments')
+    elif 'strategy_paper' in inclusion_criteria:
+        experiments_table = get_platform_paper_experiment_table(limit_to_closest_active=False)
+        multi_session_df = multi_session_df[multi_session_df.ophys_experiment_id.isin(experiments_table.index.values)]
+        print('there are', len(multi_session_df.ophys_experiment_id.unique()), 'experiments in the multi_session_df after limiting to strategy paper')
     else:
         experiments_table = get_filtered_ophys_experiment_table()
 

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -98,7 +98,7 @@ def get_platform_analysis_cache_dir():
     This cache contains NWB files downloaded directly from AWS
     """
     return r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache'
-    #return r'\\allen\programs\braintv\workgroups\nc-ophys\visual_behavior\platform_paper_cache'
+    # return r'\\allen\programs\braintv\workgroups\nc-ophys\visual_behavior\platform_paper_cache'
 
 
 def get_production_cache_dir():

--- a/visual_behavior/data_access/loading.py
+++ b/visual_behavior/data_access/loading.py
@@ -97,8 +97,8 @@ def get_platform_analysis_cache_dir():
     This is the cache directory to use for all platform paper analysis
     This cache contains NWB files downloaded directly from AWS
     """
-    # return r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache'
-    return r'\\allen\programs\braintv\workgroups\nc-ophys\visual_behavior\platform_paper_cache'
+    return r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/platform_paper_cache'
+    #return r'\\allen\programs\braintv\workgroups\nc-ophys\visual_behavior\platform_paper_cache'
 
 
 def get_production_cache_dir():

--- a/visual_behavior/database.py
+++ b/visual_behavior/database.py
@@ -244,7 +244,7 @@ def populate_id_dict(input_id_dict):
         'ophys_experiment_id': None,
     }
 
-    assert(len(input_id_dict) == 1), "use only one ID type to identify others"
+    assert (len(input_id_dict) == 1), "use only one ID type to identify others"
     for key in input_id_dict:
         assert key in ids.keys(), "input key must be one of {}".format(list(ids.keys()))
         ids[key] = input_id_dict[key]
@@ -559,7 +559,7 @@ def simplify_type(x):
     elif is_uuid(x):
         return str(x)
     elif is_array(x):
-        return[simplify_type(e) for e in x]
+        return [simplify_type(e) for e in x]
     else:
         return x
 

--- a/visual_behavior/utilities.py
+++ b/visual_behavior/utilities.py
@@ -16,7 +16,7 @@ from . import database as db
 
 from visual_behavior.ophys.sync.sync_dataset import Dataset
 from visual_behavior.data_access import loading
-import visual_behavior.visualization.behavior as behavior
+#import visual_behavior.visualization.behavior as behavior
 
 
 def flatten_list(in_list):

--- a/visual_behavior/utilities.py
+++ b/visual_behavior/utilities.py
@@ -16,7 +16,7 @@ from . import database as db
 
 from visual_behavior.ophys.sync.sync_dataset import Dataset
 from visual_behavior.data_access import loading
-#import visual_behavior.visualization.behavior as behavior
+# import visual_behavior.visualization.behavior as behavior
 
 
 def flatten_list(in_list):

--- a/visual_behavior/validation/extended_trials.py
+++ b/visual_behavior/validation/extended_trials.py
@@ -820,7 +820,7 @@ def merge_in_omitted_flashes(visual_stimuli, omitted_stimuli):
         elif six.PY3:
             visual_stimuli = pd.concat((visual_stimuli, omitted_stimuli), sort=True).sort_values(by='frame').reset_index()
         else:
-            raise(RuntimeError)
+            raise (RuntimeError)
 
     # was previous flash omitted?
     visual_stimuli['previous_omitted'] = visual_stimuli['omitted'].shift()
@@ -936,7 +936,7 @@ def validate_initial_blank(trials, visual_stimuli, omitted_stimuli, initial_blan
             elif six.PY3:
                 visual_stimuli = pd.concat((visual_stimuli, omitted_stimuli), sort=True).sort_values(by='frame').reset_index()
             else:
-                raise(RuntimeError)
+                raise (RuntimeError)
 
         # preallocate array
         initial_blank_in_tolerance = np.empty(len(trials))


### PR DESCRIPTION
- [x] Fixes a path issue #829 
- [x] Fixes a circular import #831 
   - I do this by removing the import of `visual_behavior.visualization.behavior` which breaks the function `visual_behavior.utilities.cache_response_probability()`
   - I specifically am not fixing the linting issue caused by removing this import